### PR TITLE
Add support for test methods

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -88,3 +88,14 @@ def test_unused_port_fixture(unused_tcp_port):
 
     server1.close()
     yield from server1.wait_closed()
+
+
+class Test:
+    """Test that asyncio marked functions work in test methods."""
+
+    @pytest.mark.asyncio
+    def test_asyncio_marker_method(self):
+        """Test the asyncio pytest marker in a Test class."""
+        url = 'http://httpbin.org/get'
+        resp = yield from simple_http_client(url)
+        assert b'HTTP/1.1 200 OK' in resp


### PR DESCRIPTION
- Inspired on the default implementation for pytest_pyfunc_call for normal test functions
- Refactor pytest_pyfunc_call to remove duplication

fixes #5

(BTW @Tinche, hope you don't mind me creating a branch in this repository instead of on a fork... let me know if you prefer the latter).