### PR TITLE
Make it possible to avoid using the global loop

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -45,7 +45,7 @@ def pytest_pyfunc_call(pyfuncitem):
             testargs = {arg: funcargs[arg]
                         for arg in pyfuncitem._fixtureinfo.argnames}
             event_loop.run_until_complete(
-                asyncio.async(pyfuncitem.obj(**testargs)))
+                asyncio.async(pyfuncitem.obj(**testargs), loop=event_loop))
             return True
 
 

--- a/tests/test_non_global_loop.py
+++ b/tests/test_non_global_loop.py
@@ -1,0 +1,33 @@
+import asyncio
+
+import pytest
+
+
+def setup_module(module):
+    asyncio.set_event_loop(None)
+
+
+def teardown_module(module):
+    # restore the default policy
+    asyncio.set_event_loop_policy(None)
+
+
+@pytest.fixture
+def event_loop(request):
+    loop = asyncio.new_event_loop()
+    request.addfinalizer(loop.close)
+    return loop
+
+
+@asyncio.coroutine
+def example_coroutine():
+    return 42
+
+
+@pytest.mark.asyncio
+def test_asyncio_marker_with_non_global_loop(event_loop):
+    with pytest.raises(RuntimeError):
+        _ = asyncio.get_event_loop()
+
+    result = yield from example_coroutine()
+


### PR DESCRIPTION
I'm working on a project that aims not to depend on the implicit global loop; that is, if a client developer [explicitly passes an event loop instance][PEP3156] to classes and functions in this package, only that loop will be used.

Because many other packages, including `asyncio` itself, will get the default loop when not passed an instance explicitly, we would like to run our tests against a non-global loop instance to enforce this requirement.

To that end, I tried overriding the `event_loop` fixture, but I found that the pytest-asyncio marker is implicitly retrieving the default event loop via the call to `asyncio.async`. This proposed change simply passes `event_loop` explicitly to `asyncio.async`.

I wrote the corresponding test in its own module so that I could override the `event_loop` fixture and verify that asyncio marked test functions run correctly even if there is no default event loop set.

[PEP3156]: https://www.python.org/dev/peps/pep-3156/#passing-an-event-loop-around-explicitly "PEP 3156"