### PR TITLE
gracefully handle contexts with no existing event loop

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -71,7 +71,7 @@ def event_loop(request):
 
     try:
         current_loop = policy.get_event_loop()
-    except RuntimeError:
+    except (RuntimeError, AssertionError):
         pass
     else:
         current_loop.close()

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -69,13 +69,18 @@ def event_loop(request):
     """Create an instance of the default event loop for each test case."""
     policy = asyncio.get_event_loop_policy()
 
-    policy.get_event_loop().close()
+    try:
+        current_loop = policy.get_event_loop()
+    except RuntimeError:
+        pass
+    else:
+        current_loop.close()
+    finally:
+        event_loop = policy.new_event_loop()
+        policy.set_event_loop(event_loop)
 
-    event_loop = policy.new_event_loop()
-    policy.set_event_loop(event_loop)
-
-    request.addfinalizer(event_loop.close)
-    return event_loop
+        request.addfinalizer(event_loop.close)
+        return event_loop
 
 
 @pytest.fixture

--- a/tests/test_non_global_loop.py
+++ b/tests/test_non_global_loop.py
@@ -26,11 +26,11 @@ def example_coroutine():
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 5),
-    reason='exceptiontype changed in Python 3.5'
+    (3, 3) < sys.version_info < (3, 5),
+    reason='exception type is different in Python 3.4 only'
 )
 @pytest.mark.asyncio
-def test_asyncio_marker_with_non_global_loop_py34(event_loop):
+def test_asyncio_marker_with_non_global_loop(event_loop):
     with pytest.raises(RuntimeError):
         _ = asyncio.get_event_loop()
 
@@ -38,11 +38,11 @@ def test_asyncio_marker_with_non_global_loop_py34(event_loop):
 
 
 @pytest.mark.skipif(
-    sys.version_info >= (3, 5),
-    reason='exception type changed in Python 3.5'
+    ((3, 3) >= sys.version_info) or (sys.version_info >= (3, 5)),
+    reason='exception type is different in Python 3.4 only'
 )
 @pytest.mark.asyncio
-def test_asyncio_marker_with_non_global_loop_py35(event_loop):
+def test_asyncio_marker_with_non_global_loop_py34(event_loop):
     with pytest.raises(AssertionError):
         _ = asyncio.get_event_loop()
 

--- a/tests/test_non_global_loop.py
+++ b/tests/test_non_global_loop.py
@@ -38,7 +38,7 @@ def test_asyncio_marker_with_non_global_loop(event_loop):
 
 
 @pytest.mark.skipif(
-    ((3, 3) >= sys.version_info) or (sys.version_info >= (3, 5)),
+    ((3, 4) > sys.version_info) or (sys.version_info >= (3, 5)),
     reason='exception type is different in Python 3.4 only'
 )
 @pytest.mark.asyncio

--- a/tests/test_non_global_loop.py
+++ b/tests/test_non_global_loop.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 import pytest
 
@@ -24,10 +25,25 @@ def example_coroutine():
     return 42
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 5),
+    reason='exceptiontype changed in Python 3.5'
+)
 @pytest.mark.asyncio
-def test_asyncio_marker_with_non_global_loop(event_loop):
+def test_asyncio_marker_with_non_global_loop_py34(event_loop):
     with pytest.raises(RuntimeError):
         _ = asyncio.get_event_loop()
 
     result = yield from example_coroutine()
 
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 5),
+    reason='exception type changed in Python 3.5'
+)
+@pytest.mark.asyncio
+def test_asyncio_marker_with_non_global_loop_py35(event_loop):
+    with pytest.raises(AssertionError):
+        _ = asyncio.get_event_loop()
+
+    result = yield from example_coroutine()


### PR DESCRIPTION
On Windows 7 with Python 3.5.1, running the test suite produced several occurrences of the following exception:

```
_____________ ERROR at setup of test_unused_port_factory_fixture ______________

request = <SubRequest 'event_loop' for <Function 'test_unused_port_factory_fixture'>>

    @pytest.fixture
    def event_loop(request):
        """Create an instance of the default event loop for each test case."""
        policy = asyncio.get_event_loop_policy()

>       policy.get_event_loop().close()

..\pytest_asyncio\plugin.py:72:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <asyncio.windows_events._WindowsDefaultEventLoopPolicy object at 0x0000000003D40860>

    def get_event_loop(self):
        """Get the event loop.

            This may be None or an instance of EventLoop.
            """
        if (self._local._loop is None and
            not self._local._set_called and
            isinstance(threading.current_thread(), threading._MainThread)):
            self.set_event_loop(self.new_event_loop())
        if self._local._loop is None:
            raise RuntimeError('There is no current event loop in thread %r.'
>                              % threading.current_thread().name)
E           RuntimeError: There is no current event loop in thread 'MainThread'.`
```

By checking if `policy.get_event_loop()` raises a `RuntimeError` before attempting to close the existing event loop in the `event_loop` fixture, this error is avoided.