### PR TITLE
Packaging and testing cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ python:
   - "3.5"
   - "3.6"
 
-install:
-    - pip install tox tox-travis
+install: pip install tox-travis coveralls
 
 script: tox
 
-after_success:
-    - pip install coveralls && cd tests && coveralls
+after_success: coveralls

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,13 @@
+[coverage:run]
+source = pytest_asyncio
+
+[coverage:report]
+show_missing = true
+
+[tool:pytest]
+addopts = -rsx --tb=short --cov
+testpaths = tests
+
 [metadata]
 # ensure LICENSE is included in wheel metadata
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,11 @@
-import codecs
-import os
 import re
+from pathlib import Path
+
 from setuptools import setup, find_packages
 
-with open('README.rst') as f:
-    readme = f.read()
 
-
-def read(*parts):
-    here = os.path.abspath(os.path.dirname(__file__))
-    return codecs.open(os.path.join(here, *parts), 'r').read()
-
-
-def find_version(*file_paths):
-    version_file = read(*file_paths)
+def find_version():
+    version_file = Path(__file__).parent.joinpath('pytest_asyncio', '__init__.py').read_text()
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
                               version_file, re.M)
     if version_match:
@@ -21,16 +13,17 @@ def find_version(*file_paths):
 
     raise RuntimeError("Unable to find version string.")
 
+
 setup(
     name='pytest-asyncio',
-    version=find_version('pytest_asyncio', '__init__.py'),
+    version=find_version(),
     packages=find_packages(),
     url='https://github.com/pytest-dev/pytest-asyncio',
     license='Apache 2.0',
-    author='Tin Tvrtkovic',
+    author='Tin Tvrtković',
     author_email='tinchester@gmail.com',
     description='Pytest support for asyncio.',
-    long_description=readme,
+    long_description=Path(__file__).parent.joinpath('README.rst').read_text(),
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -40,11 +33,13 @@ setup(
         "Topic :: Software Development :: Testing",
         "Framework :: Pytest",
     ],
+    python_requires='>= 3.5',
     install_requires=[
         'pytest >= 3.0.6',
     ],
     extras_require={
-        ':python_version == "3.5"': 'async_generator >= 1.3'
+        ':python_version == "3.5"': 'async_generator >= 1.3',
+        'testing': ['pytest-cov', 'async_generator >= 1.3'],
     },
     entry_points={
         'pytest11': ['asyncio = pytest_asyncio.plugin'],

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,0 @@
-coverage==4.1
-tox==2.5.0
-async_generator==1.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,7 @@
 [tox]
 envlist = py35, py36
+minversion = 2.5.0
 
 [testenv]
-deps =
-    pip >= 6
-    -rtest_requirements.txt
-commands =
-    coverage run --source pytest_asyncio -m py.test
-    coverage report
-changedir = tests
+extras = testing
+commands = python -m pytest {posargs}


### PR DESCRIPTION
Mostly cosmetic simplifications and improvements in the testing and packaging setup.
Highlights:

* Use pytest-cov for test coverage
* Removed test_requirements.txt in favor of a `testing` extras (`pip install -e .[testing]`)
* Added `python_requires` to packaging metadata
* Use Pathlib for reading file contents