### PR TITLE
handle case when no event loop exists (support pytest-aiohttp)

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -129,7 +129,12 @@ def pytest_fixture_setup(fixturedef, request):
             if kw not in request.keywords:
                 continue
             policy = asyncio.get_event_loop_policy()
-            old_loop = policy.get_event_loop()
+            try:
+                old_loop = policy.get_event_loop()
+            except RuntimeError as exc:
+                if 'no current event loop' not in str(exc):
+                    raise
+                old_loop = None
             policy.set_event_loop(loop)
             fixturedef.addfinalizer(lambda: policy.set_event_loop(old_loop))
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -7,7 +7,7 @@ import pytest_asyncio.plugin
 
 
 @asyncio.coroutine
-def async_coro(loop):
+def async_coro(loop=None):
     """A very simple coroutine."""
     yield from asyncio.sleep(0, loop=loop)
     return 'ok'
@@ -142,4 +142,19 @@ class Test:
     def test_asyncio_marker_method(self, event_loop):
         """Test the asyncio pytest marker in a Test class."""
         ret = yield from async_coro(event_loop)
+        assert ret == 'ok'
+
+
+class TestUnexistingLoop:
+    @pytest.fixture
+    def remove_loop(self):
+        old_loop = asyncio.get_event_loop()
+        asyncio.set_event_loop(None)
+        yield
+        asyncio.set_event_loop(old_loop)
+
+    @pytest.mark.asyncio
+    def test_asyncio_marker_without_loop(self, remove_loop):
+        """Test the asyncio pytest marker in a Test class."""
+        ret = yield from async_coro()
         assert ret == 'ok'


### PR DESCRIPTION
Solves this:
- https://github.com/pytest-dev/pytest-asyncio/issues/52

And this:
- https://github.com/aio-libs/aiohttp/issues/1069

Now pytest-asyncio and pytest-aiohttp can act together with this conftest.py:

```python
from aiohttp.test_utils import loop_context


@pytest.yield_fixture
def loop():
    with loop_context() as _loop:
        yield _loop


@pytest.yield_fixture
def event_loop(loop):
    yield loop
```