### PR TITLE
asyncio marker works if no event loop is set

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -129,9 +129,12 @@ def pytest_fixture_setup(fixturedef, request):
             if kw not in request.keywords:
                 continue
             policy = asyncio.get_event_loop_policy()
-            old_loop = policy.get_event_loop()
+            try:
+                old_loop = policy.get_event_loop()
+                fixturedef.addfinalizer(lambda: policy.set_event_loop(old_loop))
+            except RuntimeError:
+                pass
             policy.set_event_loop(loop)
-            fixturedef.addfinalizer(lambda: policy.set_event_loop(old_loop))
 
 
 @pytest.mark.tryfirst

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -7,7 +7,7 @@ import pytest_asyncio.plugin
 
 
 @asyncio.coroutine
-def async_coro(loop):
+def async_coro(loop=None):
     """A very simple coroutine."""
     yield from asyncio.sleep(0, loop=loop)
     return 'ok'
@@ -142,4 +142,20 @@ class Test:
     def test_asyncio_marker_method(self, event_loop):
         """Test the asyncio pytest marker in a Test class."""
         ret = yield from async_coro(event_loop)
+        assert ret == 'ok'
+
+
+class TestUnexistingLoop:
+
+    @pytest.fixture
+    def remove_loop(self):
+        old_loop = asyncio.get_event_loop()
+        asyncio.set_event_loop(None)
+        yield
+        asyncio.set_event_loop(old_loop)
+
+    @pytest.mark.asyncio
+    def test_asyncio_marker_without_loop(self, remove_loop):
+        """Test the asyncio pytest marker in a Test class."""
+        ret = yield from async_coro()
         assert ret == 'ok'


### PR DESCRIPTION
There is at least one edge case where there is no event loop when https://github.com/pytest-dev/pytest-asyncio/compare/master...argaen:catch_when_no_loop?expand=1#diff-4d85e8313d8e67cb777137411a11ac86R133 is reached.

When combining pytest-aiohttp and this package (only with 0.6.0 version) tests are crashing saying there is no event loop running. I believe the error is produced because pytest-aiohttp does the following: https://github.com/aio-libs/aiohttp/blob/master/aiohttp/pytest_plugin.py#L145 and then when pytest-asyncio reaches the line where it has to get the loop, there is no loop. This PR provides a try/except for controlling this case.

I was checking previous versions of this package to see why it wasn't crashing but from what I can see it has changed quite a lot