### PR TITLE
Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: python
-python:
-  - "3.5"
-  - "3.6"
+matrix:
+  include:
+    - python: 3.5
+      env: TOX_ENV=py35
+    - python: 3.6
+      env: TOX_ENV=py36
+    - python: 3.7
+      env: TOX_ENV=py37
+      # TODO: the dist and sudo keys are currently needed to use Python 3.7.
+      # They should be removed once Travis-CI supports 3.7 on the default image.
+      dist: xenial
+      sudo: true
 
 install: pip install tox-travis coveralls
 
-script: tox
+script: tox -e $TOX_ENV
 
 after_success:
   - tox -e coverage-report

--- a/README.rst
+++ b/README.rst
@@ -88,12 +88,6 @@ If the ``pytest.mark.asyncio`` marker is applied, a pytest hook will
 ensure the produced loop is set as the default global loop.
 Fixtures depending on the ``event_loop`` fixture can expect the policy to be properly modified when they run.
 
-``event_loop_process_pool``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ``event_loop_process_pool`` fixture is almost identical to the
-``event_loop`` fixture, except the created event loop will have a
-``concurrent.futures.ProcessPoolExecutor`` set as the default executor.
-
 ``unused_tcp_port``
 ~~~~~~~~~~~~~~~~~~~
 Finds and yields a single unused TCP port on the localhost interface. Useful for
@@ -176,17 +170,15 @@ Only test coroutines will be affected (by default, coroutines prefixed by
 .. |pytestmark| replace:: ``pytestmark``
 .. _pytestmark: http://doc.pytest.org/en/latest/example/markers.html#marking-whole-classes-or-modules
 
-``pytest.mark.asyncio_process_pool``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ``asyncio_process_pool`` marker is almost identical to the ``asyncio``
-marker, except the event loop used will have a
-``concurrent.futures.ProcessPoolExecutor`` set as the default executor.
-
 Changelog
 ---------
 
 0.9.0 (UNRELEASED)
 ~~~~~~~~~~~~~~~~~~
+- Python 3.7 support
+- Remove ``event_loop_process_pool`` fixture and
+  ``pytest.mark.asyncio_process_pool`` marker (see
+  https://bugs.python.org/issue34075 for deprecation and removal details)
 
 0.8.0 (2017-09-23)
 ~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Testing",
         "Framework :: Pytest",
     ],

--- a/tests/async_fixtures/test_coroutine_fixtures.py
+++ b/tests/async_fixtures/test_coroutine_fixtures.py
@@ -16,14 +16,12 @@ def mock():
 
 
 @pytest.fixture
-@asyncio.coroutine
-def coroutine_fixture(mock):
-    yield from asyncio.sleep(0.1, result=mock(START))
+async def coroutine_fixture(mock):
+    await asyncio.sleep(0.1, result=mock(START))
 
 
 @pytest.mark.asyncio
-@asyncio.coroutine
-def test_coroutine_fixture(coroutine_fixture, mock):
+async def test_coroutine_fixture(coroutine_fixture, mock):
     assert mock.call_count == 1
     assert mock.call_args_list[-1] == unittest.mock.call(START)
     assert coroutine_fixture is RETVAL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,11 +14,10 @@ def dependent_fixture(event_loop):
     """A fixture dependent on the event_loop fixture, doing some cleanup."""
     counter = 0
 
-    @asyncio.coroutine
-    def just_a_sleep():
+    async def just_a_sleep():
         """Just sleep a little while."""
         nonlocal event_loop
-        yield from asyncio.sleep(0.1, loop=event_loop)
+        await asyncio.sleep(0.1, loop=event_loop)
         nonlocal counter
         counter += 1
 

--- a/tests/multiloop/test_alternative_loops.py
+++ b/tests/multiloop/test_alternative_loops.py
@@ -5,13 +5,12 @@ import pytest
 
 
 @pytest.mark.asyncio
-def test_for_custom_loop():
+async def test_for_custom_loop():
     """This test should be executed using the custom loop."""
-    yield from asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)
     assert type(asyncio.get_event_loop()).__name__ == "CustomSelectorLoop"
 
 
 @pytest.mark.asyncio
-@asyncio.coroutine
-def test_dependent_fixture(dependent_fixture):
-    yield from asyncio.sleep(0.1)
+async def test_dependent_fixture(dependent_fixture):
+    await asyncio.sleep(0.1)

--- a/tests/test_dependent_fixtures.py
+++ b/tests/test_dependent_fixtures.py
@@ -3,7 +3,6 @@ import pytest
 
 
 @pytest.mark.asyncio
-@asyncio.coroutine
-def test_dependent_fixture(dependent_fixture):
+async def test_dependent_fixture(dependent_fixture):
     """Test a dependent fixture."""
-    yield from asyncio.sleep(0.1)
+    await asyncio.sleep(0.1)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -6,10 +6,9 @@ import pytest
 import pytest_asyncio.plugin
 
 
-@asyncio.coroutine
-def async_coro(loop=None):
+async def async_coro(loop=None):
     """A very simple coroutine."""
-    yield from asyncio.sleep(0, loop=loop)
+    await asyncio.sleep(0, loop=loop)
     return 'ok'
 
 
@@ -53,66 +52,64 @@ def test_asyncio_marker_with_default_param(a_param=None):
 
 
 @pytest.mark.asyncio_process_pool
-def test_asyncio_process_pool_marker(event_loop):
+async def test_asyncio_process_pool_marker(event_loop):
     """Test the asyncio pytest marker."""
-    ret = yield from async_coro(event_loop)
+    ret = await async_coro(event_loop)
     assert ret == 'ok'
 
 
 @pytest.mark.asyncio
-def test_unused_port_fixture(unused_tcp_port, event_loop):
+async def test_unused_port_fixture(unused_tcp_port, event_loop):
     """Test the unused TCP port fixture."""
 
-    @asyncio.coroutine
-    def closer(_, writer):
+    async def closer(_, writer):
         writer.close()
 
-    server1 = yield from asyncio.start_server(closer, host='localhost',
-                                              port=unused_tcp_port,
-                                              loop=event_loop)
+    server1 = await asyncio.start_server(closer, host='localhost',
+                                         port=unused_tcp_port,
+                                         loop=event_loop)
 
     with pytest.raises(IOError):
-        yield from asyncio.start_server(closer, host='localhost',
-                                        port=unused_tcp_port,
-                                        loop=event_loop)
+        await asyncio.start_server(closer, host='localhost',
+                                   port=unused_tcp_port,
+                                   loop=event_loop)
 
     server1.close()
-    yield from server1.wait_closed()
+    await server1.wait_closed()
 
 
 @pytest.mark.asyncio
-def test_unused_port_factory_fixture(unused_tcp_port_factory, event_loop):
+async def test_unused_port_factory_fixture(unused_tcp_port_factory, event_loop):
     """Test the unused TCP port factory fixture."""
 
-    @asyncio.coroutine
-    def closer(_, writer):
+    async def closer(_, writer):
         writer.close()
 
     port1, port2, port3 = (unused_tcp_port_factory(), unused_tcp_port_factory(),
                            unused_tcp_port_factory())
 
-    server1 = yield from asyncio.start_server(closer, host='localhost',
-                                              port=port1,
-                                              loop=event_loop)
-    server2 = yield from asyncio.start_server(closer, host='localhost',
-                                              port=port2,
-                                              loop=event_loop)
-    server3 = yield from asyncio.start_server(closer, host='localhost',
-                                              port=port3,
-                                              loop=event_loop)
+    server1 = await asyncio.start_server(closer, host='localhost',
+                                         port=port1,
+                                         loop=event_loop)
+    server2 = await asyncio.start_server(closer, host='localhost',
+                                         port=port2,
+                                         loop=event_loop)
+    server3 = await asyncio.start_server(closer, host='localhost',
+                                         port=port3,
+                                         loop=event_loop)
 
     for port in port1, port2, port3:
         with pytest.raises(IOError):
-            yield from asyncio.start_server(closer, host='localhost',
-                                            port=port,
-                                            loop=event_loop)
+            await asyncio.start_server(closer, host='localhost',
+                                       port=port,
+                                       loop=event_loop)
 
     server1.close()
-    yield from server1.wait_closed()
+    await server1.wait_closed()
     server2.close()
-    yield from server2.wait_closed()
+    await server2.wait_closed()
     server3.close()
-    yield from server3.wait_closed()
+    await server3.wait_closed()
 
 
 def test_unused_port_factory_duplicate(unused_tcp_port_factory, monkeypatch):
@@ -139,9 +136,9 @@ class Test:
     """Test that asyncio marked functions work in test methods."""
 
     @pytest.mark.asyncio
-    def test_asyncio_marker_method(self, event_loop):
+    async def test_asyncio_marker_method(self, event_loop):
         """Test the asyncio pytest marker in a Test class."""
-        ret = yield from async_coro(event_loop)
+        ret = await async_coro(event_loop)
         assert ret == 'ok'
 
 
@@ -154,7 +151,7 @@ class TestUnexistingLoop:
         asyncio.set_event_loop(old_loop)
 
     @pytest.mark.asyncio
-    def test_asyncio_marker_without_loop(self, remove_loop):
+    async def test_asyncio_marker_without_loop(self, remove_loop):
         """Test the asyncio pytest marker in a Test class."""
-        ret = yield from async_coro()
+        ret = await async_coro()
         assert ret == 'ok'

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -19,20 +19,6 @@ def test_event_loop_fixture(event_loop):
     assert ret == 'ok'
 
 
-def test_event_loop_processpool_fixture(event_loop_process_pool):
-    """Test the injection of the event_loop with a process pool fixture."""
-    assert event_loop_process_pool
-
-    ret = event_loop_process_pool.run_until_complete(
-        async_coro(event_loop_process_pool))
-    assert ret == 'ok'
-
-    this_pid = os.getpid()
-    future = event_loop_process_pool.run_in_executor(None, os.getpid)
-    pool_pid = event_loop_process_pool.run_until_complete(future)
-    assert this_pid != pool_pid
-
-
 @pytest.mark.asyncio
 def test_asyncio_marker():
     """Test the asyncio pytest marker."""
@@ -49,13 +35,6 @@ def test_asyncio_marker_fail():
 def test_asyncio_marker_with_default_param(a_param=None):
     """Test the asyncio pytest marker."""
     yield  # sleep(0)
-
-
-@pytest.mark.asyncio_process_pool
-async def test_asyncio_process_pool_marker(event_loop):
-    """Test the asyncio pytest marker."""
-    ret = await async_coro(event_loop)
-    assert ret == 'ok'
 
 
 @pytest.mark.asyncio

--- a/tests/test_simple_35.py
+++ b/tests/test_simple_35.py
@@ -4,7 +4,7 @@ import asyncio
 import pytest
 
 
-@asyncio.coroutine
+@pytest.mark.asyncio
 async def async_coro(loop):
     await asyncio.sleep(0, loop=loop)
     return 'ok'

--- a/tests/test_simple_35.py
+++ b/tests/test_simple_35.py
@@ -20,12 +20,6 @@ async def test_asyncio_marker_with_default_param(a_param=None):
     """Test the asyncio pytest marker."""
 
 
-@pytest.mark.asyncio_process_pool
-async def test_asyncio_process_pool_marker(event_loop):
-    ret = await async_coro(event_loop)
-    assert ret == 'ok'
-
-
 @pytest.mark.asyncio
 async def test_unused_port_fixture(unused_tcp_port, event_loop):
     """Test the unused TCP port fixture."""

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -7,20 +7,18 @@ import pytest
 
 
 @pytest.mark.asyncio(forbid_global_loop=False)
-@asyncio.coroutine
-def test_subprocess(event_loop):
+async def test_subprocess(event_loop):
     """Starting a subprocess should be possible."""
-    proc = yield from asyncio.subprocess.create_subprocess_exec(
+    proc = await asyncio.subprocess.create_subprocess_exec(
         sys.executable, '--version', stdout=asyncio.subprocess.PIPE,
         loop=event_loop)
-    yield from proc.communicate()
+    await proc.communicate()
 
 
 @pytest.mark.asyncio(forbid_global_loop=True)
-@asyncio.coroutine
-def test_subprocess_forbid(event_loop):
+async def test_subprocess_forbid(event_loop):
     """Starting a subprocess should be possible."""
-    proc = yield from asyncio.subprocess.create_subprocess_exec(
+    proc = await asyncio.subprocess.create_subprocess_exec(
         sys.executable, '--version', stdout=asyncio.subprocess.PIPE,
         loop=event_loop)
-    yield from proc.communicate()
+    await proc.communicate()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36
+envlist = py35, py36, py37
 minversion = 2.5.0
 
 [testenv]


### PR DESCRIPTION
- Enable tests and declare support for Python 3.7
- Use `async` and `await` in all tests
-  Remove ProcessPoolExecutor support

   Remove the `event_loop_process_pool` fixture and the
   `pytest.mark.asyncio_process_pool` marker to address deprecation and
   removal detailed in https://bugs.python.org/issue34075.

Fixes #87.

~Note: this change may be blocked by #87. The behavior of the
`ProcessPoolExecutor` tests is somewhat flaky in 3.7 and may cause the
test suite to hang.~
Because this change is blocked by #87, I've rolled the fix into this PR.
I can split this up if desired.