### PR TITLE
Fix: Avoid warning on latest Pytest versions

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -174,12 +174,16 @@ def event_loop(request):
     loop.close()
 
 
-@pytest.fixture
-def unused_tcp_port():
+def _unused_tcp_port():
     """Find an unused localhost TCP port from 1024-65535 and return it."""
     with contextlib.closing(socket.socket()) as sock:
         sock.bind(('127.0.0.1', 0))
         return sock.getsockname()[1]
+
+
+@pytest.fixture
+def unused_tcp_port():
+    return _unused_tcp_port()
 
 
 @pytest.fixture
@@ -189,10 +193,10 @@ def unused_tcp_port_factory():
 
     def factory():
         """Return an unused port."""
-        port = unused_tcp_port()
+        port = _unused_tcp_port()
 
         while port in produced:
-            port = unused_tcp_port()
+            port = _unused_tcp_port()
 
         produced.add(port)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ show_missing = true
 [tool:pytest]
 addopts = -rsx --tb=short
 testpaths = tests
+filterwarnings = error
 
 [metadata]
 # ensure LICENSE is included in wheel metadata

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -104,7 +104,7 @@ def test_unused_port_factory_duplicate(unused_tcp_port_factory, monkeypatch):
         else:
             return 10000 + counter
 
-    monkeypatch.setattr(pytest_asyncio.plugin, 'unused_tcp_port',
+    monkeypatch.setattr(pytest_asyncio.plugin, '_unused_tcp_port',
                         mock_unused_tcp_port)
 
     assert unused_tcp_port_factory() == 10000

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ minversion = 2.5.0
 
 [testenv]
 extras = testing
-commands = coverage run -m pytest -W error {posargs}
+commands = coverage run -m pytest {posargs}
 
 [testenv:coverage-report]
 deps = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ minversion = 2.5.0
 
 [testenv]
 extras = testing
-commands = coverage run -m pytest {posargs}
+commands = coverage run -m pytest -W error {posargs}
 
 [testenv:coverage-report]
 deps = coverage


### PR DESCRIPTION
Pytest added a deprecation warning to signal fixtures being called
directly as functions.

Ref: https://github.com/pytest-dev/pytest/issues/3661
Ref: https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly