### PR TITLE
Add clock event loop as default

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -198,20 +198,23 @@ _markers_2_fixtures = {
 
 def _event_loop_policy():
     """
-    Create a new class for ClockEventLoop based on the current
-    class-type produced by `asyncio.new_event_loop()`.  This is important
+    Create a new class for ClockEventLoopPolicy based on the current
+    class-type produced by `asyncio.get_event_loop_policy()`.  This is important
     for instances in which the enent-loop-policy has been changed.
     """
     class ClockEventLoopPolicy(asyncio.get_event_loop_policy().__class__):
-        """
-        A custom event loop that explicitly advances time when requested. Otherwise,
-        this event loop advances time as expected.
-        """
+        "A custom event loop policy for ClockEventLoop"
+
         def new_event_loop(self):
             parent_loop = super().new_event_loop()
             parent_loop.close()
 
             class ClockEventLoop(parent_loop.__class__):
+                """
+                A custom event loop that explicitly advances time when requested. Otherwise,
+                this event loop advances time as expected.
+                """
+
                 def __init__(self, *args, **kwargs):
                     super().__init__(*args, **kwargs)
                     self._clockoffset = 0
@@ -239,7 +242,10 @@ def _event_loop_policy():
                     # scheduled for running in the next pass through the event loop
                     return self.create_task(asyncio.sleep(0))
 
+            # return the new event loop
             return ClockEventLoop()
+
+    # return the new event loop policy
     return ClockEventLoopPolicy()
 
 

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -196,6 +196,7 @@ class ClockEventLoop(asyncio.new_event_loop().__class__):
 # to marked test functions
 _markers_2_fixtures = {
     'asyncio': 'event_loop',
+    'asyncio_clock': 'clock_event_loop',
 }
 
 

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -218,14 +218,14 @@ class ClockEventLoop(asyncio.new_event_loop().__class__):
         self._offset += seconds
 
         # ensure waiting callbacks are run before advancing the clock
-        await asyncio.sleep(0)
+        await asyncio.sleep(0, loop=self)
 
         if seconds > 0:
             # Once the clock is adjusted, new tasks may have just been scheduled for running
             # in the next pass through the event loop and advance again for the task
             # that calls `advance_time`
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
+            await asyncio.sleep(0, loop=self)
+            await asyncio.sleep(0, loop=self)
 
 
 # maps marker to the name of the event loop fixture that will be available

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -159,7 +159,7 @@ def pytest_runtest_setup(item):
             item.fixturenames.append(fixture)
 
 
-class ClockEventLoop(asyncio.SelectorEventLoop):
+class ClockEventLoop(asyncio.new_event_loop().__class__):
     """
     A custom event loop that explicitly advances time when requested.
     """

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -212,7 +212,8 @@ class ClockEventLoop(asyncio.new_event_loop().__class__):
         Advance time by a given offset in seconds.
         '''
         if seconds < 0:
-            raise ValueError('cannot go backwards in time')
+            # cannot go backwards in time, so return immediately
+            return
 
         # advance the clock by the given offset
         self._offset += seconds

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -213,13 +213,19 @@ class ClockEventLoop(asyncio.new_event_loop().__class__):
         '''
         if seconds < 0:
             raise ValueError('cannot go backwards in time')
-        # advance the clock and run the loop
+
+        # advance the clock by the given offset
         self._offset += seconds
-        # Once advanced, new tasks may have just been scheduled for running
-        # in the next loop, advance once more to start these handlers
+
+        # ensure waiting callbacks are run before advancing the clock
         await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+
+        if seconds > 0:
+            # Once the clock is adjusted, new tasks may have just been scheduled for running
+            # in the next pass through the event loop and advance again for the task
+            # that calls `advance_time`
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
 
 
 # maps marker to the name of the event loop fixture that will be available

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -235,16 +235,12 @@ def _clock_event_loop_class():
             that will complete after all tasks scheduled for after advancement
             of time are proceeding.
             '''
-            if seconds <= 0:
-                # cannot go backwards in time, so return after one iteration of a loop
-                return self.create_task(asyncio.sleep(0))
-
-            # advance the clock by the given offset
-            self._offset += seconds
+            if seconds > 0:
+                # advance the clock by the given offset
+                self._offset += seconds
 
             # Once the clock is adjusted, new tasks may have just been
-            # scheduled for running in the next pass through the event loop and
-            # advance again for the newly ready tasks
+            # scheduled for running in the next pass through the event loop
             return self.create_task(asyncio.sleep(0))
 
     return ClockEventLoop

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -160,6 +160,9 @@ def pytest_runtest_setup(item):
 
 
 class ClockEventLoop(asyncio.SelectorEventLoop):
+    """
+    A custom event loop that explicitly advances time when requested.
+    """
     _now = 0
 
     def time(self):

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -237,14 +237,7 @@ def _clock_event_loop_class():
             '''
             if seconds <= 0:
                 # cannot go backwards in time, so return after one iteration of a loop
-                return asyncio.sleep(0)
-
-            # Add a task associated with iterating the currently "ready" tasks and handles
-            #
-            # NOTE: This can actually take place after the offset changed, but
-            # it is here to highlight that the loop is for currently ready
-            # items before offset is applied
-            self.create_task(asyncio.sleep(0))
+                return self.create_task(asyncio.sleep(0))
 
             # advance the clock by the given offset
             self._offset += seconds

--- a/tests/test_simple_35.py
+++ b/tests/test_simple_35.py
@@ -110,11 +110,11 @@ async def test_clock_loop_advance_time(clock_event_loop):
     """
     Test the sliding time event loop fixture
     """
-    # a timeout for operations using advance_time
-    NAP_TIME = 10
+    # A task is created that will sleep some number of seconds
+    SLEEP_TIME = 10
 
     # create the task
-    task = clock_event_loop.create_task(asyncio.sleep(NAP_TIME))
+    task = clock_event_loop.create_task(asyncio.sleep(SLEEP_TIME))
     assert not task.done()
 
     # start the task
@@ -122,5 +122,5 @@ async def test_clock_loop_advance_time(clock_event_loop):
     assert not task.done()
 
     # process the timeout
-    await clock_event_loop.advance_time(NAP_TIME)
+    await clock_event_loop.advance_time(SLEEP_TIME)
     assert task.done()

--- a/tests/test_simple_35.py
+++ b/tests/test_simple_35.py
@@ -93,16 +93,14 @@ async def test_mark_asyncio_clock():
     """
     Test that coroutines marked with asyncio_clock are run with a ClockEventLoop
     """
-    import pytest_asyncio
-    assert isinstance(asyncio.get_event_loop(), pytest_asyncio.plugin.ClockEventLoop)
+    assert hasattr(asyncio.get_event_loop(), 'advance_time')
 
 
 def test_clock_loop_loop_fixture(clock_event_loop):
     """
     Test that the clock_event_loop fixture returns a proper instance of the loop
     """
-    import pytest_asyncio
-    assert isinstance(asyncio.get_event_loop(), pytest_asyncio.plugin.ClockEventLoop)
+    assert hasattr(asyncio.get_event_loop(), 'advance_time')
     clock_event_loop.close()
     return 'ok'
 
@@ -112,11 +110,11 @@ async def test_clock_loop_advance_time(clock_event_loop):
     """
     Test the sliding time event loop fixture
     """
-    async def short_nap():
-        await asyncio.sleep(1)
+    # a timeout for operations using advance_time
+    NAP_TIME = 10
 
     # create the task
-    task = clock_event_loop.create_task(short_nap())
+    task = clock_event_loop.create_task(asyncio.sleep(NAP_TIME))
     assert not task.done()
 
     # start the task
@@ -124,5 +122,5 @@ async def test_clock_loop_advance_time(clock_event_loop):
     assert not task.done()
 
     # process the timeout
-    await clock_event_loop.advance_time(1)
+    await clock_event_loop.advance_time(NAP_TIME)
     assert task.done()

--- a/tests/test_simple_35.py
+++ b/tests/test_simple_35.py
@@ -86,3 +86,22 @@ class Test:
 def test_async_close_loop(event_loop):
     event_loop.close()
     return 'ok'
+
+
+def test_clock_loop(clock_event_loop):
+    assert clock_event_loop.time() == 0
+
+    async def foo():
+        await asyncio.sleep(1)
+
+    # create the task
+    task = clock_event_loop.create_task(foo())
+    assert not task.done()
+
+    # start the task
+    clock_event_loop.advance_time(0)
+    assert not task.done()
+
+    # process the timeout
+    clock_event_loop.advance_time(1)
+    assert task.done()

--- a/tests/test_simple_35.py
+++ b/tests/test_simple_35.py
@@ -91,11 +91,11 @@ def test_async_close_loop(event_loop):
 def test_clock_loop(clock_event_loop):
     assert clock_event_loop.time() == 0
 
-    async def foo():
+    async def short_nap():
         await asyncio.sleep(1)
 
     # create the task
-    task = clock_event_loop.create_task(foo())
+    task = clock_event_loop.create_task(short_nap())
     assert not task.done()
 
     # start the task

--- a/tests/test_simple_35.py
+++ b/tests/test_simple_35.py
@@ -88,25 +88,8 @@ def test_async_close_loop(event_loop):
     return 'ok'
 
 
-@pytest.mark.asyncio_clock
-async def test_mark_asyncio_clock():
-    """
-    Test that coroutines marked with asyncio_clock are run with a ClockEventLoop
-    """
-    assert hasattr(asyncio.get_event_loop(), 'advance_time')
-
-
-def test_clock_loop_loop_fixture(clock_event_loop):
-    """
-    Test that the clock_event_loop fixture returns a proper instance of the loop
-    """
-    assert hasattr(asyncio.get_event_loop(), 'advance_time')
-    clock_event_loop.close()
-    return 'ok'
-
-
-@pytest.mark.asyncio_clock
-async def test_clock_loop_advance_time(clock_event_loop):
+@pytest.mark.asyncio
+async def test_event_loop_advance_time(event_loop):
     """
     Test the sliding time event loop fixture
     """
@@ -114,13 +97,13 @@ async def test_clock_loop_advance_time(clock_event_loop):
     SLEEP_TIME = 10
 
     # create the task
-    task = clock_event_loop.create_task(asyncio.sleep(SLEEP_TIME))
+    task = event_loop.create_task(asyncio.sleep(SLEEP_TIME))
     assert not task.done()
 
     # start the task
-    await clock_event_loop.advance_time(0)
+    await event_loop.advance_time(0)
     assert not task.done()
 
     # process the timeout
-    await clock_event_loop.advance_time(SLEEP_TIME)
+    await event_loop.advance_time(SLEEP_TIME)
     assert task.done()

--- a/tests/test_simple_35.py
+++ b/tests/test_simple_35.py
@@ -88,6 +88,24 @@ def test_async_close_loop(event_loop):
     return 'ok'
 
 
+@pytest.mark.asyncio_clock
+async def test_mark_asyncio_clock():
+    """
+    Test that coroutines marked with asyncio_clock are run with a ClockEventLoop
+    """
+    import pytest_asyncio
+    assert isinstance(asyncio.get_event_loop(), pytest_asyncio.plugin.ClockEventLoop)
+
+
+def test_clock_loop_loop_fixture(clock_event_loop):
+    """
+    Test that the clock_event_loop fixture returns a proper instance of the loop
+    """
+    import pytest_asyncio
+    assert isinstance(asyncio.get_event_loop(), pytest_asyncio.plugin.ClockEventLoop)
+    clock_event_loop.close()
+    return 'ok'
+
 
 @pytest.mark.asyncio_clock
 async def test_clock_loop_advance_time(clock_event_loop):

--- a/tests/test_simple_35.py
+++ b/tests/test_simple_35.py
@@ -88,9 +88,12 @@ def test_async_close_loop(event_loop):
     return 'ok'
 
 
-def test_clock_loop(clock_event_loop):
-    assert clock_event_loop.time() == 0
 
+@pytest.mark.asyncio_clock
+async def test_clock_loop_advance_time(clock_event_loop):
+    """
+    Test the sliding time event loop fixture
+    """
     async def short_nap():
         await asyncio.sleep(1)
 
@@ -99,9 +102,9 @@ def test_clock_loop(clock_event_loop):
     assert not task.done()
 
     # start the task
-    clock_event_loop.advance_time(0)
+    await clock_event_loop.advance_time(0)
     assert not task.done()
 
     # process the timeout
-    clock_event_loop.advance_time(1)
+    await clock_event_loop.advance_time(1)
     assert task.done()


### PR DESCRIPTION
Extend #96 clock_event_loop fixture to become default event_loop
- uses a custom policy meta class that uses the existing policy to
  modify the new loop it creates.
- The new loop it creates is modified to provide `advance_time`
  coroutine for testing
- Extends #96 to make ClockEventLoop the default policy for testing

I am adding this as a separate merge request because I am uncertain if making this behavior default is desirable, so it is here for your consideration. As I mentioned in #96, if this behavior is to be as a separate event-loop, major refactoring to the `pytest_fixture_setup` and similar methods will be needed since they all assume `event_loop` is the name of the fixture for event-loops. There is currently no trivial way to allow custom event-loops in pytest-asyncio as far as I can tell. This is the reason #96 fails many of the tests.