### PR TITLE
add advance_time fixture and test (closes #83, #95, #96 #110)

### DIFF
--- a/tests/test_simple_35.py
+++ b/tests/test_simple_35.py
@@ -86,3 +86,24 @@ class Test:
 def test_async_close_loop(event_loop):
     event_loop.close()
     return 'ok'
+
+
+@pytest.mark.asyncio
+async def test_advance_time_fixture(event_loop, advance_time):
+    """
+    Test the `advance_time` fixture
+    """
+    # A task is created that will sleep some number of seconds
+    SLEEP_TIME = 10
+
+    # create the task
+    task = event_loop.create_task(asyncio.sleep(SLEEP_TIME))
+    assert not task.done()
+
+    # start the task
+    await advance_time(0)
+    assert not task.done()
+
+    # process the timeout
+    await advance_time(SLEEP_TIME)
+    assert task.done()


### PR DESCRIPTION
This is reworking of the `advance_time` method from #96 and #95 into an event-loop independent fixture. This removes the need to change the event-loop class or policy on the fly. Compared to the fixture discussed in #83, this technique does not require any private method calls to the event-loop, which potentially volatile depending on the loop implementation. One thing to keep in mind, this technique requires patching the time method of the event loop, but the original base time method is stored to reduce the assumptions required about the timing methodology, which is left up to loop creators. This should be a fairly safe implementation.