### PR TITLE
Fix issue #112: 'Dynamically calling a fixture causes a runtime error'

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -1,5 +1,6 @@
 """pytest-asyncio implementation."""
 import asyncio
+import concurrent.futures
 import contextlib
 import functools
 import inspect
@@ -94,7 +95,10 @@ def pytest_fixture_setup(fixturedef, request):
 
             request.addfinalizer(finalizer)
 
-            return loop.run_until_complete(setup())
+            pool = concurrent.futures.ThreadPoolExecutor(1)
+            loop = asyncio.new_event_loop()
+            pool.submit(asyncio.set_event_loop, loop).result()
+            return pool.submit(loop.run_until_complete, setup()).result()
 
         fixturedef.func = wrapper
 


### PR DESCRIPTION
This patch works by failing over to a [`ThreadPoolExecutor`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor) in cases where the expected event loop is already running. Notably this happens when calling [`request.getfixturevalue(argname)`](https://docs.pytest.org/en/latest/reference.html#_pytest.fixtures.FixtureRequest.getfixturevalue) because it dynamically calls a fixture that needs to be setup on an event loop that's already running the asynchronous `pytest` tests.