### PR TITLE
Shutdown async generators before closing a loop

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -206,6 +206,7 @@ def event_loop(request):
     """Create an instance of the default event loop for each test case."""
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
+    loop.run_until_complete(loop.shutdown_asyncgens())
     loop.close()
 
 


### PR DESCRIPTION
We should shutdown asynchronous generators before closing a loop to avoid warnings.