### PR TITLE
Sync wrapper for hypothesis tests uses the event loop provided by pytest-asyncio

### DIFF
--- a/tests/test_hypothesis_integration.py
+++ b/tests/test_hypothesis_integration.py
@@ -1,6 +1,7 @@
 """Tests for the Hypothesis integration, which wraps async functions in a
 sync shim for Hypothesis.
 """
+import asyncio
 
 import pytest
 
@@ -25,3 +26,11 @@ async def test_mark_outer(n):
 async def test_mark_and_parametrize(x, y):
     assert x is None
     assert y in (1, 2)
+
+
+@given(st.integers())
+@pytest.mark.asyncio
+async def test_can_use_fixture_provided_event_loop(event_loop, n):
+    semaphore = asyncio.Semaphore(value=0, loop=event_loop)
+    event_loop.call_soon(semaphore.release)
+    await semaphore.acquire()


### PR DESCRIPTION
Async test functions marked for execution by Hypothesis are currently wrapped in a synchronous function during the test discovery phase of pytest. At this point, the `event_loop` fixture provided by pytest-asyncio has not been evaluated and the wrapper is forced to create a new loop for each hypothesis test. This may result is problems when using async-related code in fixtures as in #117.

This PR moves the wrapping code to the actual test execution. At this point the `event_loop` fixture is evaluated and there is no need to create a new loop for the test.

What's missing from this PR is a proper automated test case. Since I have run into this issue using aiohttp, I was using the following code to test it:
```python
import aiohttp
import pytest
from hypothesis import given
from hypothesis.strategies import integers


@pytest.fixture
async def http():
    async with aiohttp.ClientSession() as session:
        yield session


@pytest.mark.asyncio
@given(integers())
async def test_connect(http, n):
    await http.get('http://127.0.0.1:8080', timeout=None)
```
The test succeeds with the patch and fails otherwise.

Currently, one of the test cases still fails, so this cannot be merged. I would like to hear your comments on this, though! Especially from @Zac-HD as the original author of the hypothesis integration and @VladimirWork to see if this patch also solves his problem described in #117.