### PR TITLE
No warning on skip in asyncio

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -140,9 +140,16 @@ def wrap_in_sync(func):
     def inner(**kwargs):
         coro = func(**kwargs)
         if coro is not None:
-            future = asyncio.ensure_future(coro)
-            asyncio.get_event_loop().run_until_complete(future)
-
+            task = asyncio.ensure_future(coro)
+            try:
+                asyncio.get_event_loop().run_until_complete(task)
+            except BaseException:
+                # run_until_complete doesn't get the result from exceptions
+                # that are not subclasses of `Exception`. Consume all
+                # exceptions to prevent asyncio's warning from logging.
+                if task.done():
+                    task.exception()
+                raise
     return inner
 
 

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -147,7 +147,7 @@ def wrap_in_sync(func):
                 # run_until_complete doesn't get the result from exceptions
                 # that are not subclasses of `Exception`. Consume all
                 # exceptions to prevent asyncio's warning from logging.
-                if task.done():
+                if task.done() and not task.cancelled():
                     task.exception()
                 raise
     return inner

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -134,3 +134,8 @@ class TestUnexistingLoop:
         """Test the asyncio pytest marker in a Test class."""
         ret = await async_coro()
         assert ret == 'ok'
+
+
+@pytest.mark.asyncio
+async def test_no_warning_on_skip():
+    pytest.skip("Need a skip error inside asyncio")

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -138,4 +138,4 @@ class TestUnexistingLoop:
 
 @pytest.mark.asyncio
 async def test_no_warning_on_skip():
-    pytest.skip("Need a skip error inside asyncio")
+    pytest.skip("Test a skip error inside asyncio")


### PR DESCRIPTION
Asyncio doesn't get the results of tasks that fail with exceptions that
don't subclass `Exception` (like pytest's `Skipped`) in
`run_until_complete`. This leads to asyncio logging noisily warning when
pytest's skip functionality is mixed with this plugin.

This fixes this error, and adds a test.

Fixes #123.