### PR TITLE
Fixing file encoding per PEP-263

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import re
 from pathlib import Path
 


### PR DESCRIPTION
Python source defaults to ASCII without encoding hints.