### PR TITLE
Replace yield_fixture() by fixture()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ event loop. This will take effect even if you're using the
 
 .. code-block:: python
 
-    @pytest.yield_fixture()
+    @pytest.fixture
     def event_loop():
         loop = MyCustomLoop()
         yield loop

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -166,7 +166,7 @@ def pytest_runtest_setup(item):
             )
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def event_loop(request):
     """Create an instance of the default event loop for each test case."""
     loop = asyncio.get_event_loop_policy().new_event_loop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ if sys.version_info[:2] < (3, 6):
     collect_ignore.append("async_fixtures/test_nested_36.py")
 
 
-@pytest.yield_fixture()
+@pytest.fixture
 def dependent_fixture(event_loop):
     """A fixture dependent on the event_loop fixture, doing some cleanup."""
     counter = 0

--- a/tests/multiloop/conftest.py
+++ b/tests/multiloop/conftest.py
@@ -8,7 +8,7 @@ class CustomSelectorLoop(asyncio.SelectorEventLoop):
     pass
 
 
-@pytest.yield_fixture()
+@pytest.fixture
 def event_loop():
     """Create an instance of the default event loop for each test case."""
     loop = CustomSelectorLoop()


### PR DESCRIPTION
`@pytest.yield_fixture` is deprecated since pytest-3.0, see:
https://docs.pytest.org/en/latest/yieldfixture.html