### PR TITLE
Update plugin.py to enable asyncio debugging

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -170,6 +170,7 @@ def pytest_runtest_setup(item):
 def event_loop(request):
     """Create an instance of the default event loop for each test case."""
     loop = asyncio.get_event_loop_policy().new_event_loop()
+    loop.set_debug(True)
     yield loop
     loop.close()
 


### PR DESCRIPTION
Changed plugin.py to enable debug on the event loop fixture.

This allows any tasks that are not closed correctly to be logged 
in such a way that we can see which test they originate from, 
which is incredibly useful in testing large libraries where a test
somewhere may not be awaiting something correctly or may be
closing the event loop without terminating tasks correctly.