### PR TITLE
don't use deprecated pytest.yield_fixture in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ event loop. This will take effect even if you're using the
 
 .. code-block:: python
 
-    @pytest.yield_fixture()
+    @pytest.fixture()
     def event_loop():
         loop = MyCustomLoop()
         yield loop


### PR DESCRIPTION
See https://docs.pytest.org/en/latest/yieldfixture.html:

> ## Important
>
> Since pytest-3.0, fixtures using the normal fixture decorator can use a yield statement to provide fixture values and execute teardown code, exactly like yield_fixture in previous versions.
>
> Marking functions as yield_fixture is still supported, but deprecated and should not be used in new code.
