### PR TITLE
Fix unittests and add max supported pytest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "testing": [
             "coverage",
             "async_generator >= 1.3",
-            "hypothesis >= 3.64",
+            "hypothesis >= 5.7.1",
         ],
     },
     entry_points={"pytest11": ["asyncio = pytest_asyncio.plugin"]},

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Framework :: Pytest",
     ],
     python_requires=">= 3.5",
-    install_requires=["pytest >= 3.6.0"],
+    install_requires=["pytest >= 3.6.0, < 5.4.0"],
     extras_require={
         ':python_version == "3.5"': "async_generator >= 1.3",
         "testing": [

--- a/tests/test_hypothesis_integration.py
+++ b/tests/test_hypothesis_integration.py
@@ -8,6 +8,12 @@ import pytest
 from hypothesis import given, strategies as st
 
 
+@pytest.fixture(scope="module")
+def event_loop():
+    loop = asyncio.get_event_loop()
+    yield loop
+
+
 @given(st.integers())
 @pytest.mark.asyncio
 async def test_mark_inner(n):

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -6,6 +6,17 @@ import asyncio.subprocess
 import pytest
 
 
+if sys.platform == 'win32':
+    # The default asyncio event loop implementation on Windows does not
+    # support subprocesses. Subprocesses are available for Windows if a
+    # ProactorEventLoop is used.
+    @pytest.yield_fixture()
+    def event_loop():
+        loop = asyncio.ProactorEventLoop()
+        yield loop
+        loop.close()
+
+
 @pytest.mark.asyncio(forbid_global_loop=False)
 async def test_subprocess(event_loop):
     """Starting a subprocess should be possible."""


### PR DESCRIPTION
This PR contains 3 changes:
* Fix for running test_subprocess on windows by following instructions on https://docs.python.org/3.7/library/asyncio-subprocess.html#creating-subprocesses
* Change event_loop-fixture to module-scope in hypothesis tests, fixes #145 
* Change setup.py max version of pytest to avoid failures because of changes in 5.4.0 until #141 merged. It should be reverted in that PR.