### PR TITLE
Fix event_loop is run after other fixtures

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -154,9 +154,11 @@ def wrap_in_sync(func):
 
 
 def pytest_runtest_setup(item):
-    if 'asyncio' in item.keywords and 'event_loop' not in item.fixturenames:
+    if 'asyncio' in item.keywords:
         # inject an event loop fixture for all async tests
-        item.fixturenames.append('event_loop')
+        if 'event_loop' in item.fixturenames:
+            item.fixturenames.remove('event_loop')
+        item.fixturenames.insert(0, 'event_loop')
     if item.get_closest_marker("asyncio") is not None \
         and not getattr(item.obj, 'hypothesis', False) \
         and getattr(item.obj, 'is_hypothesis_test', False):

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -128,6 +128,29 @@ class TestUnexistingLoop:
         assert ret == 'ok'
 
 
+class TestEventLoopStartedBeforeFixtures:
+    @pytest.fixture
+    async def loop(self):
+        return asyncio.get_event_loop()
+
+    @staticmethod
+    def foo():
+        return 1
+
+    @pytest.mark.asyncio
+    async def test_no_event_loop(self, loop):
+        assert await loop.run_in_executor(None, self.foo) == 1
+
+    @pytest.mark.asyncio
+    async def test_event_loop_after_fixture(self, loop, event_loop):
+        assert await loop.run_in_executor(None, self.foo) == 1
+
+    @pytest.mark.asyncio
+    async def test_event_loop_before_fixture(self, event_loop, loop):
+        assert await loop.run_in_executor(None, self.foo) == 1
+
+
+
 @pytest.mark.asyncio
 async def test_no_warning_on_skip():
     pytest.skip("Test a skip error inside asyncio")


### PR DESCRIPTION
Resolves #154, resolves #157, resolves #158 
Also adds unittests for the use case.

Not ready for merge, breaks `test_asyncio_marker_without_loop`, which was added in #64.
https://github.com/pytest-dev/pytest-asyncio/blob/a7e5795335b823b4d58bb6b38b6e653f0e0d35b0/tests/test_simple.py#L116-L128

Discussion for possible fix of broken test below