### PR TITLE
plugin: Set unused_tcp_port_factory scope to 'session'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,8 @@ Changelog
 ~~~~~~~~~~~~~~~~~~~
 - Add support for Python 3.9
 - Abandon support for Python 3.5. If you still require support for Python 3.5, please use pytest-asyncio v0.14 or earlier.
+- Set ``unused_tcp_port_factory`` fixture scope to 'session'.
+  `#163 <https://github.com/pytest-dev/pytest-asyncio/pull/163>`_
 
 0.14.0 (2020-06-24)
 ~~~~~~~~~~~~~~~~~~~

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -219,7 +219,7 @@ def unused_tcp_port():
     return _unused_tcp_port()
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def unused_tcp_port_factory():
     """A factory function, producing different unused TCP ports."""
     produced = set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,3 +20,10 @@ def dependent_fixture(event_loop):
     event_loop.run_until_complete(just_a_sleep())
 
     assert counter == 2
+
+
+@pytest.fixture(scope='session', name='factory_involving_factories')
+def factory_involving_factories_fixture(unused_tcp_port_factory):
+    def factory():
+        return unused_tcp_port_factory()
+    return factory

--- a/tests/test_dependent_fixtures.py
+++ b/tests/test_dependent_fixtures.py
@@ -6,3 +6,8 @@ import pytest
 async def test_dependent_fixture(dependent_fixture):
     """Test a dependent fixture."""
     await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_factory_involving_factories(factory_involving_factories):
+    factory_involving_factories()


### PR DESCRIPTION
Factories in pytest usually have a scope greater than 'function' to allow
one use the same factory within bigger scopes. Let us allow
unused_tcp_port_factory to be used throughout the same session scope.
This will allow other session-scoped factories depend on
unused_tcp_port_factory without getting a "ScopeMismatch" error.