### PR TITLE
Fix new tests

### DIFF
--- a/tests/custom_policy/test_alternative_policies.py
+++ b/tests/custom_policy/test_alternative_policies.py
@@ -4,8 +4,13 @@ import asyncio
 import pytest
 
 
+def test_execute_event_loop_policy_first(event_loop_policy):
+    """This test assures event_loop_policy fixture is executed before event_loop fixture"""
+    assert type(asyncio.get_event_loop()).__name__ == "CustomSelectorLoop"
+
+
 @pytest.mark.asyncio
-async def test_for_custom_loop():
+async def test_for_custom_loop_policy():
     """This test should be executed using the custom loop."""
     await asyncio.sleep(0.01)
     assert type(asyncio.get_event_loop()).__name__ == "CustomSelectorLoop"
@@ -17,7 +22,7 @@ async def test_dependent_fixture(dependent_fixture):
 
 
 @pytest.mark.asyncio
-async def test_for_custom_loop_2():
+async def test_for_custom_loop_policy_2():
     """This test should be executed using the custom loop."""
     await asyncio.sleep(0.01)
     assert type(asyncio.get_event_loop()).__name__ == "CustomSelectorLoop"


### PR DESCRIPTION
The only problem with new tests are that event_loop fixture is executed before event_loop_policy fixture. 

Adding a first test (not async), depending on event_loop_policy fixture, forces to execute it the first.

