### PR TITLE
Teardown of the event_loop fixture no longer replaces the event loop policy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,10 @@ Only test coroutines will be affected (by default, coroutines prefixed by
 
 Changelog
 ---------
+0.17.0 (UNRELEASED)
+~~~~~~~~~~~~~~~~~~~
+- `pytest-asyncio` no longer alters existing event loop policies. `#168 <https://github.com/pytest-dev/pytest-asyncio/issues/168>`_, `#188 <https://github.com/pytest-dev/pytest-asyncio/issues/168>`_
+
 0.16.0 (2021-10-16)
 ~~~~~~~~~~~~~~~~~~~
 - Add support for Python 3.10

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -80,8 +80,11 @@ class FixtureStripper:
 def pytest_fixture_post_finalizer(fixturedef, request):
     """Called after fixture teardown"""
     if fixturedef.argname == "event_loop":
-        # Set empty loop policy, so that subsequent get_event_loop() provides a new loop
-        asyncio.set_event_loop_policy(None)
+        policy = asyncio.get_event_loop_policy()
+        policy.get_event_loop().close()  # Clean up existing loop to avoid ResourceWarnings
+        new_loop = policy.new_event_loop()  # Replace existing event loop
+        # Ensure subsequent calls to get_event_loop() succeed
+        policy.set_event_loop(new_loop)
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/respect_event_loop_policy/conftest.py
+++ b/tests/respect_event_loop_policy/conftest.py
@@ -1,0 +1,16 @@
+"""Defines and sets a custom event loop policy"""
+import asyncio
+from asyncio import DefaultEventLoopPolicy, SelectorEventLoop
+
+
+class TestEventLoop(SelectorEventLoop):
+    pass
+
+
+class TestEventLoopPolicy(DefaultEventLoopPolicy):
+    def new_event_loop(self):
+        return TestEventLoop()
+
+
+# This statement represents a code which sets a custom event loop policy
+asyncio.set_event_loop_policy(TestEventLoopPolicy())

--- a/tests/respect_event_loop_policy/test_respects_event_loop_policy.py
+++ b/tests/respect_event_loop_policy/test_respects_event_loop_policy.py
@@ -1,0 +1,16 @@
+"""Tests that any externally provided event loop policy remains unaltered."""
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_uses_loop_provided_by_custom_policy():
+    """Asserts that test cases use the event loop provided by the custom event loop policy"""
+    assert type(asyncio.get_event_loop()).__name__ == "TestEventLoop"
+
+
+@pytest.mark.asyncio
+async def test_custom_policy_is_not_overwritten():
+    """Asserts that any custom event loop policy stays the same across test cases"""
+    assert type(asyncio.get_event_loop()).__name__ == "TestEventLoop"


### PR DESCRIPTION
My understanding is that everyone is happy, if the event loop policy remains unaltered. I think I found a way to get rid of the code that resets the event loop policy.

## Problem
Here is my understanding of the problem:
We need to make sure that each test case runs in an isolated fashion. Therefore, the `event_loop` fixture provides a fresh event loop and is automatically applied to all marked tests. When the fixture goes out of scope, it closes the event loop. Subsequent test cases would run into the following error:
```
RuntimeError: Event loop is closed
```

This is prevented a dedicated [fixture teardown](https://github.com/pytest-dev/pytest-asyncio/blob/4e2e6bd16682f6d3f8597cf5d7a86521a847e7ba/pytest_asyncio/plugin.py#L75-L80) prodecure. The teardown sets the event loop policy to `None`, which also disposes the existing, closed event loop. Subsequent calls to `asyncio.get_event_loop()` will return a fresh loop. The problem is that setting the event loop policy to None resets the policy to the system default, which may be undesired.

## Solution
Instead of resetting the event loop policy, the same effect can be achieved by requesting a new loop to replace the existing, closed event loop:
```
@pytest.hookimpl(trylast=True)
def pytest_fixture_post_finalizer(fixturedef, request):
    """Called after fixture teardown"""
    if fixturedef.argname == "event_loop":
        policy = asyncio.get_event_loop_policy()
        new_loop = policy.new_event_loop()  # Replace existing event loop
        policy.set_event_loop(new_loop)  # Ensure subsequent calls to get_event_loop() succeed
```

## Considerations
What I dislike about this solution is that a new loop is created during the _teardown_ of the `event_loop` fixture. It feels wrong to do it here. The correct place would be to create a new loop during fixture setup. In fact, the fixture _does_ create another loop so we effectively create two new event loops for each test run. This points to an issue with the order in which the fixtures are evaluated.

What are your thoughts on this approach?

Resolves #168
Resolves #188 