### PR TITLE
Resolve event loop closed issue when trying a second attempt with `flaky`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ target/
 
 .venv*
 .idea
+.vscode

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -186,6 +186,12 @@ def wrap_in_sync(func, _loop):
     """Return a sync wrapper around an async function executing it in the
     current event loop."""
 
+    # if the function is already wrapped, we rewrap using the original one
+    # not using __wrapped__ because the original function may already be
+    # a wrapped one
+    if hasattr(func, '_raw_test_func'):
+        func = func._raw_test_func
+
     @functools.wraps(func)
     def inner(**kwargs):
         coro = func(**kwargs)
@@ -201,6 +207,7 @@ def wrap_in_sync(func, _loop):
                     task.exception()
                 raise
 
+    inner._raw_test_func = func
     return inner
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "testing": [
             "coverage",
             "hypothesis >= 5.7.1",
+            "flaky >= 3.5.0"
         ],
     },
     entry_points={"pytest11": ["asyncio = pytest_asyncio.plugin"]},

--- a/tests/test_flaky_integration.py
+++ b/tests/test_flaky_integration.py
@@ -1,0 +1,17 @@
+"""Tests for the Flaky integration, which retries failed tests.
+"""
+import asyncio
+
+import flaky
+import pytest
+
+_threshold = -1
+
+
+@flaky.flaky(3, 2)
+@pytest.mark.asyncio
+async def test_asyncio_flaky_thing_that_fails_then_succeeds():
+    global _threshold
+    await asyncio.sleep(0.1)
+    _threshold += 1
+    assert _threshold != 1


### PR DESCRIPTION
When using [flaky](https://github.com/box/flaky) along with `pytest-asyncio`, for instance,

```python
@flaky.flaky(3)
@pytest.mark.asyncio
async def test_errors():
    raise ValueError
```

when the first attempt failed, the second attempt will raise `RuntimeError: Event loop is closed` (given https://github.com/box/flaky/issues/166). The reason is that the wrapper https://github.com/pytest-dev/pytest-asyncio/blob/6ec76477061ea14394cadbf2cef673b04971ef4d/pytest_asyncio/plugin.py#L185 will be called twice in  `pytest_pyfunc_call` and the previous closed loop is still used. The resolution is to record the original function and wrap the original function every time.

Fixes #178