### PR TITLE
Async fixtures work even if event loop is running in another thread

### DIFF
--- a/tests/test_thread_safe_fixtures.py
+++ b/tests/test_thread_safe_fixtures.py
@@ -1,0 +1,33 @@
+import asyncio
+import threading
+
+import pytest
+
+
+@pytest.fixture(scope="package")
+def event_loop():
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    is_ready = threading.Event()
+
+    def run_forever():
+        is_ready.set()
+        loop.run_forever()
+
+    thread = threading.Thread(target=lambda: run_forever(), daemon=True)
+    thread.start()
+    is_ready.wait()
+    yield loop
+
+
+@pytest.fixture(scope="package")
+async def async_fixture(event_loop):
+    await asyncio.sleep(0)
+    yield "fixture"
+
+
+@pytest.mark.asyncio
+def test_event_loop_thread_safe(async_fixture):
+    """Make sure that async fixtures still work, even if the event loop
+    is running in another thread.
+    """
+    assert async_fixture == "fixture"


### PR DESCRIPTION
Currently, `pytest-asyncio` works fine with event loops running on a different thread, until you try to add async fixtures. Async fixtures break because `loop.run_until_complete` is used to run the `setup` and `finalizer` functions defined for the fixture, which is not thread-safe. This results in a `RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one`.

This PR adds a fn to check if the loop is running, and also not equal to the current running loop. If that's the case, it has to be running on a different thread. In that case we use `asyncio.run_coroutine_threadsafe` instead of `run_until_complete` to execute the coroutine, which solves the issue.

Added minimal test that fails without the fix.