### PR TITLE
Use `python@3.10` in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: "actions/checkout@v2"


### PR DESCRIPTION
`3.10-dev` is no longer required, because `3.10` and `3.10.1` are released.