### PR TITLE
Remove use of obsolete transfer_markers during test collection phase

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -7,15 +7,6 @@ import socket
 
 import pytest
 
-try:
-    from _pytest.python import transfer_markers
-except ImportError:  # Pytest 4.1.0 removes the transfer_marker api (#104)
-
-    def transfer_markers(*args, **kwargs):  # noqa
-        """Noop when over pytest 4.1.0"""
-        pass
-
-
 from inspect import isasyncgenfunction
 
 
@@ -39,13 +30,6 @@ def pytest_pycollect_makeitem(collector, name, obj):
     """A pytest hook to collect asyncio coroutines."""
     if collector.funcnamefilter(name) and _is_coroutine(obj):
         item = pytest.Function.from_parent(collector, name=name)
-
-        # Due to how pytest test collection works, module-level pytestmarks
-        # are applied after the collection step. Since this is the collection
-        # step, we look ourselves.
-        transfer_markers(obj, item.cls, item.module)
-        item = pytest.Function.from_parent(collector, name=name)  # To reload keywords.
-
         if "asyncio" in item.keywords:
             return list(collector._genfunctions(name, obj))
 


### PR DESCRIPTION
`transfer_markers` was removed in Pytest 4.1. The minimum required pytest version for pytest-asyncio is currently v5.4.0. That means that `transfer_markers` is always a no-op.