### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,11 @@ jobs:
     name: "Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-latest"
     env:
-      USING_COVERAGE: "3.6,3.7,3.8,3.9,3.10"
+      USING_COVERAGE: "3.7,3.8,3.9,3.10"
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/README.rst
+++ b/README.rst
@@ -167,6 +167,7 @@ Changelog
 0.17.0 (UNRELEASED)
 ~~~~~~~~~~~~~~~~~~~
 - `pytest-asyncio` no longer alters existing event loop policies. `#168 <https://github.com/pytest-dev/pytest-asyncio/issues/168>`_, `#188 <https://github.com/pytest-dev/pytest-asyncio/issues/168>`_
+- Drop support for Python 3.6
 
 0.16.0 (2021-10-16)
 ~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -41,7 +40,7 @@ setup(
         "Topic :: Software Development :: Testing",
         "Framework :: Pytest",
     ],
-    python_requires=">= 3.6",
+    python_requires=">= 3.7",
     install_requires=["pytest >= 5.4.0"],
     extras_require={
         "testing": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.14.0
-envlist = py36, py37, py38, py39, py310, lint
+envlist = py37, py38, py39, py310, lint
 skip_missing_interpreters = true
 
 [testenv]
@@ -26,7 +26,6 @@ commands =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39, lint


### PR DESCRIPTION
CPython 3.6 reached end-of-life on 2021-12-23 [1]. Future releases of pytest will no longer support Python 3.6 [2].

We should consider dropping support for unmaintained Python versions.

[1] https://www.python.org/dev/peps/pep-0494/
[2] https://github.com/pytest-dev/pytest/pull/9437