### PR TITLE
Reformat with black

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -176,7 +176,7 @@ def wrap_in_sync(func, _loop):
     # if the function is already wrapped, we rewrap using the original one
     # not using __wrapped__ because the original function may already be
     # a wrapped one
-    if hasattr(func, '_raw_test_func'):
+    if hasattr(func, "_raw_test_func"):
         func = func._raw_test_func
 
     @functools.wraps(func)

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,9 @@ from setuptools import setup, find_packages
 
 def find_version():
     version_file = (
-        Path(__file__)
-        .parent.joinpath("pytest_asyncio", "__init__.py")
-        .read_text()
+        Path(__file__).parent.joinpath("pytest_asyncio", "__init__.py").read_text()
     )
-    version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M
-    )
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
 
@@ -44,11 +40,7 @@ setup(
     python_requires=">= 3.7",
     install_requires=["pytest >= 5.4.0"],
     extras_require={
-        "testing": [
-            "coverage",
-            "hypothesis >= 5.7.1",
-            "flaky >= 3.5.0"
-        ],
+        "testing": ["coverage", "hypothesis >= 5.7.1", "flaky >= 3.5.0"],
     },
     entry_points={"pytest11": ["asyncio = pytest_asyncio.plugin"]},
 )


### PR DESCRIPTION
`setup.py` is also reformatted for the sake of uniformness.