### PR TITLE
Release process automation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,12 @@ jobs:
       prerelease: ${{ steps.version.outputs.prerelease }}
     steps:
       - uses: "actions/checkout@v2"
+        fetch-depth: 0
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
 
-      - name: "Install poetry, check-wheel-content, and twine"
+      - name: "Install check-wheel-content, and twine"
         run: "python -m pip install build check-wheel-contents tox twine"
       - name: "Build package"
         run: "python -m build"
@@ -53,6 +54,7 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v2"
+        fetch-depth: 0
       - uses: "actions/setup-python@v2"
         with:
           python-version: "${{ matrix.python-version }}"
@@ -89,26 +91,27 @@ jobs:
     needs: [lint, check]
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2.4.0
-    - name: Download disctributions
-      uses: actions/download-artifact@v2
-      with:
-        name: dist
-        path: dist
-    - name: Collected dists
-      run: |
-        tree dist
-    - name: PyPI upload
-      uses: pypa/gh-action-pypi-publish@v1.4.2
-      with:
-        packages_dir: dist
-        password: ${{ secrets.PYPI_API_TOKEN }}
-    - name: GitHub Release
-      uses: ncipollo/release-action@v1
-      with:
-        name: 'pytest-asyncio ${{ needs.lint.outputs.version }}'
-        artifacts: dist
-        bodyFile: README.rst
-        prerelease: ${{ needs.lint.outputs.prerelease }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+        fetch-depth: 0
+      - name: Download disctributions
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Collected dists
+        run: |
+          tree dist
+      - name: PyPI upload
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          packages_dir: dist
+          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          name: 'pytest-asyncio ${{ needs.lint.outputs.version }}'
+          artifacts: dist
+          bodyFile: README.rst
+          prerelease: ${{ needs.lint.outputs.prerelease }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.4.0
         fetch-depth: 0
-      - name: Download disctributions
+      - name: Download distributions
         uses: actions/download-artifact@v2
         with:
           name: dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,38 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    name: "Run linters"
+    runs-on: "ubuntu-latest"
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.9"
+
+      - name: "Install poetry, check-wheel-content, and twine"
+        run: "python -m pip install build check-wheel-contents twine"
+      - name: "Build package"
+        run: "python -m build"
+      - name: "Run tox for linter"
+        run: "python -m tox -e lint"
+      - name: "List result"
+        run: "ls -l dist"
+      - name: "Check wheel contents"
+        run: "check-wheel-contents dist/*.whl"
+      - name: "Check long_description"
+        run: "python -m twine check dist/*"
+      - name: "Get version info"
+        run: "tox -e version-info"
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+
   test:
     name: "Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-latest"
@@ -41,7 +73,7 @@ jobs:
   check:
     name: Check
     if: always()
-    needs: [test]
+    needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
@@ -51,23 +83,32 @@ jobs:
       - name: Upload coverage
         uses: aio-libs/upload-coverage@v21.9.4
 
-  package:
-    name: "Build & verify package"
-    runs-on: "ubuntu-latest"
-
+  deploy:
+    name: Deploy
+    environment: release
+    needs: [lint, check]
+    runs-on: ubuntu-latest
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v2"
-        with:
-          python-version: "3.9"
-
-      - name: "Install poetry, check-wheel-content, and twine"
-        run: "python -m pip install build check-wheel-contents twine"
-      - name: "Build package"
-        run: "python -m build"
-      - name: "List result"
-        run: "ls -l dist"
-      - name: "Check wheel contents"
-        run: "check-wheel-contents dist/*.whl"
-      - name: "Check long_description"
-        run: "python -m twine check dist/*"
+    - name: Checkout
+      uses: actions/checkout@v2.4.0
+    - name: Download disctributions
+      uses: actions/download-artifact@v2
+      with:
+        name: dist
+        path: dist
+    - name: Collected dists
+      run: |
+        tree dist
+    - name: PyPI upload
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        packages_dir: dist
+        password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: GitHub Release
+      uses: ncipollo/release-action@v1
+      with:
+        name: 'pytest-asyncio ${{ needs.lint.outputs.version }}'
+        artifacts: dist
+        bodyFile: README.rst
+        prerelease: ${{ needs.lint.outputs.prerelease }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,8 @@ jobs:
     deploy:
         name: Deploy
         environment: release
+        # Run only on pushing a tag
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         needs: [lint, check]
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.9"
 
       - name: "Install poetry, check-wheel-content, and twine"
-        run: "python -m pip install build check-wheel-contents twine"
+        run: "python -m pip install build check-wheel-contents tox twine"
       - name: "Build package"
         run: "python -m build"
       - name: "Run tox for linter"

--- a/tools/get-version.py
+++ b/tools/get-version.py
@@ -1,0 +1,17 @@
+import json
+import sys
+from importlib import metadata
+
+from packaging.version import parse as parse_version
+
+
+def main():
+    version_string = metadata.version("pytest-asyncio")
+    version = parse_version(version_string)
+    print(f"::set-output name=version::{version}")
+    prerelease = json.dumps(version.is_prerelease)
+    print(f"::set-output name=prerelease::{prerelease}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,25 @@
 [tox]
 minversion = 3.14.0
-envlist = py37, py38, py39, py310, lint
+envlist = py37, py38, py39, py310, lint, version-info
 skip_missing_interpreters = true
+passenv =
+    CI
 
 [testenv]
 extras = testing
 commands = make test
+allowlist_externals =
+    make
 
 [testenv:lint]
 skip_install = true
 basepython = python3.9
-extras = tests
 deps =
-    pre-commit
+    pre-commit == 2.16.0
 commands =
     make lint
+allowlist_externals =
+    make
 
 [testenv:coverage-report]
 deps = coverage
@@ -22,6 +27,13 @@ skip_install = true
 commands =
     coverage combine
     coverage report
+
+[testenv:version-info]
+basepython = python3.9
+deps =
+    packaging == 21.3
+commands =
+    python ./tools/get-version.py
 
 [gh-actions]
 python =


### PR DESCRIPTION
The release is created on git tag pushing.

After linters and tests passed, the deploy stage is starting to wait for release approval.

@pytest-dev/pytest-asyncio-admin can approve. If nobody approved the release in 1 day -- deployment is discarded.
After the approval, we have 15 minutes timer for starting the deployment. During these 15 mins we the deployment task can be cancelled (just in case the deployer missed something).

The new release is pushed on PyPI (using generated PyPI upload token with `pytest-asyncio` scope) and on GitHub (visible as GitHub release).

Tag naming: as usual.
`v0.16`, `v0.17`  etc means final releases.
`v0.17a0` means *0.17 alpha 0* release.
`.post` releases are supported but please avoid them -- Dependabot uses SemVer; SemVer handles it as pre-release. Better to publish the next micro-release instead.
