### PR TITLE
Fix auto marking of async hypothesis tests in auto mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,6 +256,10 @@ or an async framework such as `asynctest <https://asynctest.readthedocs.io/en/la
 
 Changelog
 ---------
+0.17.1 (UNRELEASED)
+~~~~~~~~~~~~~~~~~~~
+- Fixes a bug that prevents async Hypothesis tests from working without explicit ``asyncio`` marker when ``--asyncio-mode=auto`` is set. `#258 <https://github.com/pytest-dev/pytest-asyncio/issues/258>`_
+
 0.17.0 (22-01-13)
 ~~~~~~~~~~~~~~~~~~~
 - `pytest-asyncio` no longer alters existing event loop policies. `#168 <https://github.com/pytest-dev/pytest-asyncio/issues/168>`_, `#188 <https://github.com/pytest-dev/pytest-asyncio/issues/168>`_

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -288,7 +288,7 @@ def pytest_pyfunc_call(pyfuncitem):
     where the wrapped test coroutine is executed in an event loop.
     """
     if "asyncio" in pyfuncitem.keywords:
-        if getattr(pyfuncitem.obj, "is_hypothesis_test", False):
+        if _is_hypothesis_test(pyfuncitem.obj):
             pyfuncitem.obj.hypothesis.inner_test = wrap_in_sync(
                 pyfuncitem.obj.hypothesis.inner_test,
                 _loop=pyfuncitem.funcargs["event_loop"],
@@ -298,6 +298,10 @@ def pytest_pyfunc_call(pyfuncitem):
                 pyfuncitem.obj, _loop=pyfuncitem.funcargs["event_loop"]
             )
     yield
+
+
+def _is_hypothesis_test(function) -> bool:
+    return getattr(function, "is_hypothesis_test", False)
 
 
 def wrap_in_sync(func, _loop):


### PR DESCRIPTION
The option `--asyncio-mode=auto` marks all async functions with the `asyncio` mark during the collection phase. However, when pytest collects the Hypothesis test, the `@given` decorator has already been applied and the Hypothesis test function is no longer a coroutine.
    
This commit extends the `pytest_pycollect_makeitem` hook to mark Hypothesis tests whose function body is a coroutine.
    
 Closes #258
 

I was uncertain whether to add  the tests to the auto mode tests or to the Hypothesis tests. I eventually decided to add them to the tests for the Hypothesis integration. Rather than using `pytester` I added some assertions so the tests would fail in case we ever change `asyncio_mode` to something other than auto. Let me know what you think of this.