### PR TITLE
Provide typing info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ clean-test: ## remove test and coverage artifacts
 lint:
 # CI env-var is set by GitHub actions
 ifdef CI
-	pre-commit run --all-files --show-diff-on-failure
+	python -m pre_commit run --all-files --show-diff-on-failure
 else
-	pre-commit run --all-files
+	python -m pre_commit run --all-files
 endif
-	mypy pytest_asyncio --show-error-codes
+	python -m mypy pytest_asyncio --show-error-codes
 
 test:
 	coverage run -m pytest tests

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ ifdef CI
 else
 	pre-commit run --all-files
 endif
+	mypy pytest_asyncio --show-error-codes
 
 test:
 	coverage run -m pytest tests

--- a/README.rst
+++ b/README.rst
@@ -259,6 +259,7 @@ Changelog
 0.17.1 (UNRELEASED)
 ~~~~~~~~~~~~~~~~~~~
 - Fixes a bug that prevents async Hypothesis tests from working without explicit ``asyncio`` marker when ``--asyncio-mode=auto`` is set. `#258 <https://github.com/pytest-dev/pytest-asyncio/issues/258>`_
+- Added type annotations. `#198 <https://github.com/pytest-dev/pytest-asyncio/issues/198>`_
 
 0.17.0 (22-01-13)
 ~~~~~~~~~~~~~~~~~~~

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -8,6 +8,7 @@ import socket
 import warnings
 from typing import (
     Any,
+    AsyncIterator,
     Awaitable,
     Callable,
     Dict,
@@ -25,10 +26,18 @@ from typing import (
 import pytest
 from typing_extensions import Literal
 
+_R = TypeVar("_R")
+
 _ScopeName = Literal["session", "package", "module", "class", "function"]
 _T = TypeVar("_T")
 
-FixtureFunction = TypeVar("FixtureFunction", bound=Callable[..., object])
+SimpleFixtureFunction = TypeVar(
+    "SimpleFixtureFunction", bound=Callable[..., Awaitable[_R]]
+)
+FactoryFixtureFunction = TypeVar(
+    "FactoryFixtureFunction", bound=Callable[..., AsyncIterator[_R]]
+)
+FixtureFunction = Union[SimpleFixtureFunction, FactoryFixtureFunction]
 FixtureFunctionMarker = Callable[[FixtureFunction], FixtureFunction]
 
 Config = Any  # pytest < 7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
 
   Framework :: AsyncIO
   Framework :: Pytest
+  Typing :: Typed
 
 [options]
 python_requires = >=3.7
@@ -38,12 +39,14 @@ setup_requires =
 
 install_requires =
   pytest >= 5.4.0
+  typing-extensions >= 4.0
 
 [options.extras_require]
 testing =
   coverage==6.2
   hypothesis >= 5.7.1
   flaky >= 3.5.0
+  mypy == 0.931
 
 [options.entry_points]
 pytest11 =

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
 
 [testenv:lint]
 skip_install = true
-basepython = python3.9
+basepython = python3.10
 extras = testing
 deps =
     pre-commit == 2.16.0

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ allowlist_externals =
 [testenv:lint]
 skip_install = true
 basepython = python3.9
+extras = testing
 deps =
     pre-commit == 2.16.0
 commands =


### PR DESCRIPTION
Type checking is rough, better checks require not released yet pytest 7.0 at least.

Tests are not typed to don't pollute this big enough PR.
They can be typed later.

Fixes #198