### PR TITLE
Require typing-extensions on py<3.8 only

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -5,6 +5,7 @@ import enum
 import functools
 import inspect
 import socket
+import sys
 import warnings
 from typing import (
     Any,
@@ -24,7 +25,11 @@ from typing import (
 )
 
 import pytest
-from typing_extensions import Literal
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 _R = TypeVar("_R")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ setup_requires =
 
 install_requires =
   pytest >= 6.1.0
-  typing-extensions >= 4.0
+  typing-extensions >= 4.0; python_version < "3.8"
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
typing.Literal is available since Python 3.8.  Use it instead of
requiring typing-extensions for systems that no longer have Python 3.7.