### PR TITLE
Fix setuptools_scm configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools>=51.0",
   "wheel>=0.36",
-  "setuptools_scm>=6.2"
+  "setuptools_scm[toml]>=6.2"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,9 +34,6 @@ python_requires = >=3.7
 packages = find:
 include_package_data = True
 
-setup_requires =
-  setuptools_scm >= 6.2
-
 install_requires =
   pytest >= 6.1.0
   typing-extensions >= 4.0; python_version < "3.8"

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 minversion = 3.14.0
 envlist = py37, py38, py39, py310, lint, version-info, pytest-min
 skip_missing_interpreters = true
+isolated_build = true
 passenv =
     CI
 


### PR DESCRIPTION
`pyproject.toml` should use `setuptools_scm[toml]` dependency.
In turn, bare `setuptools_scm` should be dropped from `setup.cfg` `setup_requires` section.

@webknjaz suggested the change for another aio-libs project.