### PR TITLE
Prepare release of v0.18.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,7 +257,7 @@ or an async framework such as `asynctest <https://asynctest.readthedocs.io/en/la
 Changelog
 ---------
 
-0.18.0 (22-02-03)
+0.18.0 (22-02-07)
 ~~~~~~~~~~~~~~~~~~~
 
 - Raise a warning if @pytest.mark.asyncio is applied to non-async function. `#275 <https://github.com/pytest-dev/pytest-asyncio/issues/275>`_

--- a/README.rst
+++ b/README.rst
@@ -257,7 +257,7 @@ or an async framework such as `asynctest <https://asynctest.readthedocs.io/en/la
 Changelog
 ---------
 
-0.18.0 (Unreleased)
+0.18.0 (22-02-03)
 ~~~~~~~~~~~~~~~~~~~
 
 - Raise a warning if @pytest.mark.asyncio is applied to non-async function. `#275 <https://github.com/pytest-dev/pytest-asyncio/issues/275>`_


### PR DESCRIPTION
Is there anything that's holding us back from releasing the current changes on master as v0.18?

Apparently, the current version on `master` fixes bugs for some users (e.g. #280).