### PR TITLE
Relax dependency on typing-extensions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ include_package_data = True
 
 install_requires =
   pytest >= 6.1.0
-  typing-extensions >= 4.0; python_version < "3.8"
+  typing-extensions >= 3.7.4; python_version < "3.8"
 
 [options.extras_require]
 testing =

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ include_package_data = True
 
 install_requires =
   pytest >= 6.1.0
-  typing-extensions >= 3.7.4; python_version < "3.8"
+  typing-extensions >= 3.7.2; python_version < "3.8"
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
We only use `typing_extensions` for the `Literal` type, which is available [starting from version `3.7.2`](https://github.com/python/typing/blob/1be6269634bec97d58d68cc1243359118373580a/typing_extensions/src_py3/typing_extensions.py#L129), so we don't necessarily need `typing_extensions>=4.0`