### PR TITLE
Fix regression that prevents async fixtures from working in sync tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,6 +257,10 @@ or an async framework such as `asynctest <https://asynctest.readthedocs.io/en/la
 Changelog
 ---------
 
+0.18.1 (UNRELEASED)
+~~~~~~~~~~~~~~~~~~~
+- Fixes a regression that prevented async fixtures from working in synchronous tests. `#286 <https://github.com/pytest-dev/pytest-asyncio/issues/286>`_
+
 0.18.0 (22-02-07)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -319,12 +319,12 @@ def pytest_pycollect_makeitem(
     """A pytest hook to collect asyncio coroutines."""
     if not collector.funcnamefilter(name):
         return None
+    _preprocess_async_fixtures(collector.config, _HOLDER)
     if (
         _is_coroutine(obj)
         or _is_hypothesis_test(obj)
         and _hypothesis_test_wraps_coroutine(obj)
     ):
-        _preprocess_async_fixtures(collector.config, _HOLDER)
         item = pytest.Function.from_parent(collector, name=name)
         marker = item.get_closest_marker("asyncio")
         if marker is not None:

--- a/tests/test_asyncio_fixture.py
+++ b/tests/test_asyncio_fixture.py
@@ -1,4 +1,5 @@
 import asyncio
+from textwrap import dedent
 
 import pytest
 
@@ -39,3 +40,25 @@ async def fixture_with_params(request):
 async def test_fixture_with_params(fixture_with_params):
     await asyncio.sleep(0)
     assert fixture_with_params % 2 == 0
+
+
+@pytest.mark.parametrize("mode", ("auto", "strict", "legacy"))
+def test_sync_function_uses_async_fixture(testdir, mode):
+    testdir.makepyfile(
+        dedent(
+            """\
+        import pytest_asyncio
+
+        pytest_plugins = 'pytest_asyncio'
+
+        @pytest_asyncio.fixture
+        async def always_true():
+            return True
+
+        def test_sync_function_uses_async_fixture(always_true):
+           assert always_true is True
+        """
+        )
+    )
+    result = testdir.runpytest(f"--asyncio-mode={mode}")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
The function `_preprocess_async_fixtures` does nothing if the fixture is not an async function. The change simply prepares all async fixtures of a test regardless of whether the test is an async function or not.

Do you see any harm in doing so?

This should fix the issue encountered in #286.