### PR TITLE
Add positional arguments to the synchronous test function wrapper.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -260,6 +260,7 @@ Changelog
 0.18.2 (Unreleased)
 ~~~~~~~~~~~~~~~~~~~
 - Fix asyncio auto mode not marking static methods. `#295 <https://github.com/pytest-dev/pytest-asyncio/issues/295>`_
+- Fix a compatibility issue with Hypothesis 6.39.0. `#302 <https://github.com/pytest-dev/pytest-asyncio/issues/302>`_
 
 
 0.18.1 (22-02-10)

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -432,8 +432,8 @@ def wrap_in_sync(
         func = raw_func
 
     @functools.wraps(func)
-    def inner(**kwargs):
-        coro = func(**kwargs)
+    def inner(*args, **kwargs):
+        coro = func(*args, **kwargs)
         if not inspect.isawaitable(coro):
             pyfuncitem.warn(
                 pytest.PytestWarning(


### PR DESCRIPTION
This fixes a compatibility issue with Hypothesis 6.39.0.

No new test case was added, because the existing unit tests were already failing (see https://github.com/pytest-dev/pytest-asyncio/runs/5380149531)

Closes #302
