### PR TITLE
Do not try to initialize async fixtures without explicit asyncio mark in strict mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+UNRELEASED
+=================
+- Adds `pytest-trio <https://pypi.org/project/pytest-trio/>`_ to the test dependencies
+
 0.18.2 (22-03-03)
 =================
 - Fix asyncio auto mode not marking static methods. `#295 <https://github.com/pytest-dev/pytest-asyncio/issues/295>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 UNRELEASED
 =================
 - Adds `pytest-trio <https://pypi.org/project/pytest-trio/>`_ to the test dependencies
+- Fixes a bug that caused pytest-asyncio to try to set up async pytest_trio fixtures in strict mode. `#298 <https://github.com/pytest-dev/pytest-asyncio/issues/298>`_
 
 0.18.2 (22-03-03)
 =================

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -210,7 +210,11 @@ def _preprocess_async_fixtures(config: Config, holder: Set[FixtureDef]) -> None:
                 # Nothing to do with a regular fixture function
                 continue
             if not _has_explicit_asyncio_mark(func):
-                if asyncio_mode == Mode.AUTO:
+                if asyncio_mode == Mode.STRICT:
+                    # Ignore async fixtures without explicit asyncio mark in strict mode
+                    # This applies to pytest_trio fixtures, for example
+                    continue
+                elif asyncio_mode == Mode.AUTO:
                     # Enforce asyncio mode if 'auto'
                     _set_explicit_asyncio_mark(func)
                 elif asyncio_mode == Mode.LEGACY:

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ testing =
   hypothesis >= 5.7.1
   flaky >= 3.5.0
   mypy == 0.931
+  pytest-trio >= 0.7.0
 
 [options.entry_points]
 pytest11 =

--- a/tests/loop_fixture_scope/conftest.py
+++ b/tests/loop_fixture_scope/conftest.py
@@ -3,14 +3,14 @@ import asyncio
 import pytest
 
 
-class CustomSelectorLoopSession(asyncio.SelectorEventLoop):
+class CustomSelectorLoop(asyncio.SelectorEventLoop):
     """A subclass with no overrides, just to test for presence."""
 
 
-loop = CustomSelectorLoopSession()
+loop = CustomSelectorLoop()
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def event_loop():
     """Create an instance of the default event loop for each test case."""
     yield loop

--- a/tests/loop_fixture_scope/test_loop_fixture_scope.py
+++ b/tests/loop_fixture_scope/test_loop_fixture_scope.py
@@ -1,4 +1,4 @@
-"""Unit tests for overriding the event loop with a session scoped one."""
+"""Unit tests for overriding the event loop with a larger scoped one."""
 import asyncio
 
 import pytest
@@ -8,7 +8,7 @@ import pytest
 async def test_for_custom_loop():
     """This test should be executed using the custom loop."""
     await asyncio.sleep(0.01)
-    assert type(asyncio.get_event_loop()).__name__ == "CustomSelectorLoopSession"
+    assert type(asyncio.get_event_loop()).__name__ == "CustomSelectorLoop"
 
 
 @pytest.mark.asyncio

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -15,17 +15,8 @@ if sys.platform == "win32":
         loop.close()
 
 
-@pytest.mark.asyncio(forbid_global_loop=False)
+@pytest.mark.asyncio
 async def test_subprocess(event_loop):
-    """Starting a subprocess should be possible."""
-    proc = await asyncio.subprocess.create_subprocess_exec(
-        sys.executable, "--version", stdout=asyncio.subprocess.PIPE
-    )
-    await proc.communicate()
-
-
-@pytest.mark.asyncio(forbid_global_loop=True)
-async def test_subprocess_forbid(event_loop):
     """Starting a subprocess should be possible."""
     proc = await asyncio.subprocess.create_subprocess_exec(
         sys.executable, "--version", stdout=asyncio.subprocess.PIPE

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -15,6 +15,18 @@ if sys.platform == "win32":
         loop.close()
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="""
+        When run with Python 3.7 asyncio.subprocess.create_subprocess_exec seems to be
+        affected by an issue that prevents correct cleanup. Tests using pytest-trio
+        will report that signal handling is already performed by another library and
+        fail. [1] This is possibly a bug in CPython 3.7, so we ignore this test for
+        that Python version.
+
+        [1] https://github.com/python-trio/pytest-trio/issues/126
+    """,
+)
 @pytest.mark.asyncio
 async def test_subprocess(event_loop):
     """Starting a subprocess should be possible."""

--- a/tests/trio/test_fixtures.py
+++ b/tests/trio/test_fixtures.py
@@ -1,0 +1,25 @@
+from textwrap import dedent
+
+
+def test_strict_mode_ignores_trio_fixtures(testdir):
+    testdir.makepyfile(
+        dedent(
+            """\
+        import pytest
+        import pytest_asyncio
+        import pytest_trio
+
+        pytest_plugins = ["pytest_asyncio", "pytest_trio"]
+
+        @pytest_trio.trio_fixture
+        async def any_fixture():
+            return True
+
+        @pytest.mark.trio
+        async def test_anything(any_fixture):
+            pass
+        """
+        )
+    )
+    result = testdir.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
This fixes a bug that breaks compatibility with pytest_trio (see #298).
    
The PR:
- Adds pytest-trio to the test dependencies.
- Removes test with obsolete "forbid_global_loop".

  forbid_global_loop was an option to `pytest.mark.asyncio` which was removed in v0.6.0. The two subprocess tests are otherwise identical. Therefore, one of the tests was removed along with the obsolete option.
- Fixes a bug that causes a package-scoped event_loop fixture to leak into other tests.
    
    The expected behaviour is that the `event_loop` fixture defined in `tests/sessionloop/conftest.py` is torn down when all tests in `tests/sessionloop` are complete. Running the tests with the pytest option `--setup-show` pointed out that the fixture is torn down at the end of the test session, instead. This is an unintended side effect of the sessionloop test which may affect other tests in the test suite.
    
    Reducing the fixture scope from "package" to "module" results in the expected behaviour. The module was renamed to reflect the fact that the tests do not use a session scope.
- Ignores subprocess tests when running on CPython 3.7.
    
  When run with Python 3.7, `asyncio.subprocess.create_subprocess_exec` seems to be affected by an issue that prevents correct cleanup. Tests using pytest-trio will report that signal handling is already performed by another library and fail. [1] This is possibly a bug in CPython 3.7, so I suggest we ignore this test for that Python version.

  I've been shaving this yak for some time and this is my theory:
  CPython 3.7 uses `asyncio.streams.StreamReader` and `asyncio.streams.StreamWriter` to implement `asyncio.streams.StreamReaderProtocol` and `asyncio.subprocess.SubprocessStreamProtocol`. `StreamReaderProtocol` contained cyclic references between the reader and the protocol, which prevented garbage collection. While  `StreamReaderProtocol` received a patch [2], `SubprocessStreamProtocol`, which is used by `create_subprocess_exec`, possibly has the same problem, but was not patched as part of CPython 3.7.
  
  [1] https://github.com/python-trio/pytest-trio/issues/126
  [2] https://github.com/python/cpython/pull/9201
     