### PR TITLE
Fix CI linting workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v3
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install GitHub matcher for ActionLint checker
       run: |
         echo "::add-matcher::.github/actionlint-matcher.json"

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,6 @@ commands =
 python =
     3.7: py37, pytest-min
     3.8: py38
-    3.9: py39, lint
+    3.9: py39
     3.10: py310
     pypy3: pypy3

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 minversion = 3.14.0
 envlist = py37, py38, py39, py310, lint, version-info, pytest-min
-skip_missing_interpreters = true
 isolated_build = true
 passenv =
     CI

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ allowlist_externals =
     make
 
 [testenv:lint]
-skip_install = true
 basepython = python3.10
 extras = testing
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,6 @@ commands =
     coverage report
 
 [testenv:version-info]
-basepython = python3.9
 deps =
     packaging == 21.3
 commands =


### PR DESCRIPTION
The tox "lint" target expects Python 3.10 to be installed, but CI only installs Python 3.9. The `skip_missing_interpreters` configuration caused the "lint" workflow in CI to exit successfully, even though no linting was performed.

This PR:
- Removes the `skip_missing_interpreters` to prevent silent errors in the future.
- Installs the required Python version during the lint workflow
- Removes tox's "lint" environment from the set of "3.9" environments of a GitHub actions run.

  Linting is performed explicitly in a separate workflow and does not need to be run as part of the Python 3.9 tests. Additionally, linting currently expects Python 3.10 and will fail during the Python 3.9 test run. 
- Fixes a bug that prevented mypy to be installed correctly for tox's "lint" environment

  The lint environment requires mypy from the test dependencies to be installed. Although the environment defines `extras = testing`, it also specifies `skip_install = true`, which also skips installation of test dependencies.

 