### PR TITLE
Add cleanup code to event_loop that mimics the behavior of asyncio.run

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -494,7 +494,7 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
 @pytest.fixture
 def event_loop(request: "pytest.FixtureRequest") -> Iterator[asyncio.AbstractEventLoop]:
     """Create an instance of the default event loop for each test case."""
-    return asyncio.get_event_loop_policy().new_event_loop()
+    yield asyncio.get_event_loop_policy().new_event_loop()
     # Call the garbage collector to trigger ResourceWarning's as soon
     # as possible (these are triggered in various __del__ methods).
     # Without this, resources opened in one test can fail other tests

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -491,10 +491,11 @@ def event_loop(request: "pytest.FixtureRequest") -> Iterator[asyncio.AbstractEve
     yield loop
     # Cleanup code copied from the implementation of asyncio.run()
     try:
-        asyncio.runners._cancel_all_tasks(loop)
-        loop.run_until_complete(loop.shutdown_asyncgens())
-        if sys.version_info >= (3, 9):
-            loop.run_until_complete(loop.shutdown_default_executor())
+        if not loop.is_closed():
+            asyncio.runners._cancel_all_tasks(loop)
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            if sys.version_info >= (3, 9):
+                loop.run_until_complete(loop.shutdown_default_executor())
     finally:
         loop.close()
         # Call the garbage collector to trigger ResourceWarning's as soon

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -364,7 +364,9 @@ def pytest_fixture_post_finalizer(fixturedef: FixtureDef, request: SubRequest) -
             # Cleanup code based on the implementation of asyncio.run()
             try:
                 if not loop.is_closed():
-                    asyncio.runners._cancel_all_tasks(loop)
+                    asyncio.runners._cancel_all_tasks(  # type: ignore[attr-defined]
+                        loop
+                    )
                     loop.run_until_complete(loop.shutdown_asyncgens())
                     if sys.version_info >= (3, 9):
                         loop.run_until_complete(loop.shutdown_default_executor())

--- a/tests/test_event_loop_cleanup.py
+++ b/tests/test_event_loop_cleanup.py
@@ -1,0 +1,38 @@
+from textwrap import dedent
+
+
+def test_task_canceled_on_test_end(testdir):
+    testdir.makepyfile(
+        dedent(
+            """\
+        import asyncio
+        import pytest
+
+        pytest_plugins = 'pytest_asyncio'
+
+        @pytest.mark.asyncio
+        async def test_a():
+            loop = asyncio.get_event_loop()
+
+            async def run_forever():
+                while True:
+                    await asyncio.sleep(0.1)
+
+            loop.create_task(run_forever())
+        """
+        )
+    )
+    testdir.makefile(
+        ".ini",
+        pytest=dedent(
+            """\
+        [pytest]
+        asyncio_mode = strict
+        filterwarnings =
+            error
+    """
+        ),
+    )
+    result = testdir.runpytest_subprocess()
+    result.assert_outcomes(passed=1)
+    result.stderr.no_fnmatch_line("Task was destroyed but it is pending!")

--- a/tests/test_event_loop_scope.py
+++ b/tests/test_event_loop_scope.py
@@ -34,4 +34,7 @@ def test_3():
 def test_4(event_loop):
     # If a test sets the loop to None -- pytest_fixture_post_finalizer()
     # still should work
+
+    # Close to avoid ResourceWarning about unclosed socket as a side effect
+    event_loop.close()
     asyncio.get_event_loop_policy().set_event_loop(None)


### PR DESCRIPTION
This is something I found useful and implemented in one of my own projects so I thought I'd make a PR in case the maintainers think this would be a good addition to the library itself. I'd be happy to modify it if only a subset of the changes is desired.

Some issues that I ran into with the current implementation:
- Errors that occur in a task spawned during one test can leak into subsequent tests since simply calling `loop.close()` is not sufficient to shutdown the event loop. This can make it extremely difficult to track down which test is causing the errors, since the test that fails is not actually the one that has the problem.
- When running with `-W error` under python 3.9 a similar problem happens with ResourceWarnings, where it becomes extremely difficult to figure out which test is actually opening the resources that are generating the warnings since the GC doesn't actually clean them up until some later test is already running.

Closes #200 