### PR TITLE
Fix pre-commit-hook-yamlfmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     - markdown
     - rst
 - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-  rev: 0.1.0
+  rev: 0.1.1
   hooks:
   - id: yamlfmt
     args: [--mapping, '2', --sequence, '2', --offset, '0']


### PR DESCRIPTION
v0.1.1 fixes an incompatibility with setuptools-61.1.0
see https://github.com/jumanjihouse/pre-commit-hook-yamlfmt/issues/29