### PR TITLE
Python 3.11 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,11 +51,11 @@ jobs:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     env:
-      USING_COVERAGE: 3.7,3.8,3.9,3.10
+      USING_COVERAGE: 3.7,3.8,3.9,3.10,3.11
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 3.11-dev]
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 UNRELEASED
 =================
 - Removes `setup.py` since all relevant configuration is present `setup.cfg`. Users requiring an editable installation of pytest-asyncio need to use pip v21.1 or newer. `#283 <https://github.com/pytest-dev/pytest-asyncio/issues/283>`_
+- Add support for Python 3.11.
 
 0.18.3 (22-03-25)
 =================

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
 
   Topic :: Software Development :: Testing
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.14.0
-envlist = py37, py38, py39, py310, lint, version-info, pytest-min
+envlist = py37, py38, py39, py310, py311, lint, version-info, pytest-min
 isolated_build = true
 passenv =
     CI
@@ -52,4 +52,5 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11-dev: py311
     pypy3: pypy3


### PR DESCRIPTION
* Updates Tox and CI to run tests on Python 3.11
* Adjust changelog and Trove classifiers