### PR TITLE
opt into strict mode by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ UNRELEASED
 =================
 - BREAKING: The default ``asyncio_mode`` is now *strict*. `#293 <https://github.com/pytest-dev/pytest-asyncio/issues/293>`_
 - Removes `setup.py` since all relevant configuration is present `setup.cfg`. Users requiring an editable installation of pytest-asyncio need to use pip v21.1 or newer. `#283 <https://github.com/pytest-dev/pytest-asyncio/issues/283>`_
-- Add support for Python 3.11.
+- Declare support for Python 3.11.
 
 0.18.3 (22-03-25)
 =================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 UNRELEASED
 =================
+- BREAKING: The default ``asyncio_mode`` is now *strict*. `#293 <https://github.com/pytest-dev/pytest-asyncio/issues/293>`_
 - Removes `setup.py` since all relevant configuration is present `setup.cfg`. Users requiring an editable installation of pytest-asyncio need to use pip v21.1 or newer. `#283 <https://github.com/pytest-dev/pytest-asyncio/issues/283>`_
 - Add support for Python 3.11.
 

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Modes
 -----
 
 Starting from ``pytest-asyncio>=0.17``, three modes are provided: *auto*, *strict* and
-*legacy* (default).
+*legacy*. Starting from ``pytest-asyncio>=0.19`` the *strict* mode is the default.
 
 The mode can be set by ``asyncio_mode`` configuration option in `configuration file
 <https://docs.pytest.org/en/latest/reference/customize.html>`_:
@@ -104,6 +104,8 @@ pytest plugin can handle them.
 Please use this mode if multiple async frameworks should be combined in the same test
 suite.
 
+This mode is used by default for the sake of project inter-compatibility.
+
 
 Legacy mode
 ~~~~~~~~~~~
@@ -111,11 +113,10 @@ Legacy mode
 This mode follows rules used by ``pytest-asyncio<0.17``: tests are not auto-marked but
 fixtures are.
 
-This mode is used by default for the sake of backward compatibility, deprecation
-warnings are emitted with suggestion to either switching to ``auto`` mode or using
-``strict`` mode with ``@pytest_asyncio.fixture`` decorators.
+Deprecation warnings are emitted with suggestion to either switching to ``auto`` mode
+or using ``strict`` mode with ``@pytest_asyncio.fixture`` decorators.
 
-In future, the default will be changed.
+The default was changed to ``strict`` in ``pytest-asyncio>=0.19``.
 
 
 Fixtures

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -95,7 +95,7 @@ def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager) -> None
     parser.addini(
         "asyncio_mode",
         help="default value for --asyncio-mode",
-        default="legacy",
+        default="strict",
     )
 
 


### PR DESCRIPTION
Fixes #293

It's looking like a critical mass of projects have set `asyncio_mode=` if they need it, and an increasing number of projects are getting compatibility issues where they set `filterwarnings=error`, do not use `pytest-asyncio`, but are installed into an environment with it already.

In addition pytest has now deprecated returning not-None values https://docs.pytest.org/en/latest/deprecations.html#returning-non-none-value-in-test-functions and so in a future version test suites returning Coros will fail, rather than pass with a warning