### PR TITLE
Perform `in` (rather than `is) check against cached fixturedefs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+UNRELEASED
+=================
+- Fixed an issue which prevented fixture setup from being cached. `#404 <https://github.com/pytest-dev/pytest-asyncio/pull/404>`_
+
 0.19.0 (22-07-13)
 =================
 - BREAKING: The default ``asyncio_mode`` is now *strict*. `#293 <https://github.com/pytest-dev/pytest-asyncio/issues/293>`_

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -203,7 +203,7 @@ def _preprocess_async_fixtures(config: Config, holder: Set[FixtureDef]) -> None:
     fixturemanager = config.pluginmanager.get_plugin("funcmanage")
     for fixtures in fixturemanager._arg2fixturedefs.values():
         for fixturedef in fixtures:
-            if fixturedef is holder:
+            if fixturedef in holder:
                 continue
             func = fixturedef.func
             if not _is_coroutine_or_asyncgen(func):


### PR DESCRIPTION
If i'm off base here, feel free to close this...

but in my struggles to get my plugin working with pytest-asyncio, i kept noticing this holder check; and i couldn't possibly fathom how a ` fixturedef` would come to **be** this `_HOLDER` dict.

but it would make a lot more sense if the intent here was to avoid reexecuting the logic further down, if you already have classified that fixturedef previously.