### PR TITLE
Add deprecation warning for pytest < 7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 UNRELEASED
 =================
 - BREAKING: Removed *legacy* mode. If you're upgrading from v0.19 and you haven't configured ``asyncio_mode = legacy``, you can upgrade without taking any additional action. If you're upgrading from an earlier version or you have explicitly enabled *legacy* mode, you need to switch to *auto* or *strict* mode before upgrading to this version.
+- Deprecate use of pytest v6.
 - Fixed an issue which prevented fixture setup from being cached. `#404 <https://github.com/pytest-dev/pytest-asyncio/pull/404>`_
 
 0.19.0 (22-07-13)

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -6,6 +6,7 @@ import functools
 import inspect
 import socket
 import sys
+import warnings
 from typing import (
     Any,
     AsyncIterator,
@@ -168,6 +169,14 @@ def pytest_configure(config: Config) -> None:
         "mark the test as a coroutine, it will be "
         "run using an asyncio event loop",
     )
+
+    if getattr(pytest, "__version_tuple__", (0, 0, 0) < (7,)):
+        warnings.warn(
+            "You're using an outdated version of pytest. Newer releases of "
+            "pytest-asyncio will not be compatible with this pytest version. "
+            "Please update pytest to version 7 or later.",
+            DeprecationWarning,
+        )
 
 
 @pytest.mark.tryfirst


### PR DESCRIPTION
The last v6 release of pytest was v6.2.5 on 2021-08-29. People have had more than a year to upgrade to pytest 7. It is time to sunset support for pytest 6.
