### PR TITLE
Refactor pytest_pycollect_makeitems

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -186,11 +186,10 @@ def _preprocess_async_fixtures(
     fixturemanager = config.pluginmanager.get_plugin("funcmanage")
     for fixtures in fixturemanager._arg2fixturedefs.values():
         for fixturedef in fixtures:
-            if fixturedef in processed_fixturedefs:
-                continue
             func = fixturedef.func
-            if not _is_coroutine_or_asyncgen(func):
-                # Nothing to do with a regular fixture function
+            if fixturedef in processed_fixturedefs or not _is_coroutine_or_asyncgen(
+                func
+            ):
                 continue
             if not _is_asyncio_fixture_function(func) and asyncio_mode == Mode.STRICT:
                 # Ignore async fixtures without explicit asyncio mark in strict mode

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -306,6 +306,8 @@ def pytest_collection_modifyitems(
       - Hypothesis tests wrapping coroutines
 
     """
+    if _get_asyncio_mode(config) != Mode.AUTO:
+        return
     function_items = (item for item in items if isinstance(item, Function))
     for function_item in function_items:
         function = function_item.obj
@@ -317,8 +319,7 @@ def pytest_collection_modifyitems(
             or _is_hypothesis_test(function)
             and _hypothesis_test_wraps_coroutine(function)
         ):
-            if _get_asyncio_mode(config) == Mode.AUTO:
-                function_item.add_marker("asyncio")
+            function_item.add_marker("asyncio")
 
 
 def _hypothesis_test_wraps_coroutine(function: Any) -> bool:

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -192,13 +192,11 @@ def _preprocess_async_fixtures(
             if not _is_coroutine_or_asyncgen(func):
                 # Nothing to do with a regular fixture function
                 continue
-            if not _is_asyncio_fixture_function(func):
-                if asyncio_mode == Mode.STRICT:
-                    # Ignore async fixtures without explicit asyncio mark in strict mode
-                    # This applies to pytest_trio fixtures, for example
-                    continue
-                # Enforce asyncio mode if 'auto'
-                _make_asyncio_fixture_function(func)
+            if not _is_asyncio_fixture_function(func) and asyncio_mode == Mode.STRICT:
+                # Ignore async fixtures without explicit asyncio mark in strict mode
+                # This applies to pytest_trio fixtures, for example
+                continue
+            _make_asyncio_fixture_function(func)
 
             to_add = []
             for name in ("request", "event_loop"):

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -196,15 +196,7 @@ def _preprocess_async_fixtures(
                 # This applies to pytest_trio fixtures, for example
                 continue
             _make_asyncio_fixture_function(func)
-
-            to_add = []
-            for name in ("request", "event_loop"):
-                if name not in fixturedef.argnames:
-                    to_add.append(name)
-
-            if to_add:
-                fixturedef.argnames += tuple(to_add)
-
+            _inject_fixture_argnames(fixturedef)
             if inspect.isasyncgenfunction(func):
                 fixturedef.func = _wrap_asyncgen(func)
             elif inspect.iscoroutinefunction(func):
@@ -212,6 +204,18 @@ def _preprocess_async_fixtures(
 
             assert _is_asyncio_fixture_function(fixturedef.func)
             processed_fixturedefs.add(fixturedef)
+
+
+def _inject_fixture_argnames(fixturedef: FixtureDef) -> None:
+    """
+    Ensures that `request` and `event_loop` are arguments of the specified fixture.
+    """
+    to_add = []
+    for name in ("request", "event_loop"):
+        if name not in fixturedef.argnames:
+            to_add.append(name)
+    if to_add:
+        fixturedef.argnames += tuple(to_add)
 
 
 def _add_kwargs(

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -197,11 +197,7 @@ def _preprocess_async_fixtures(
                 continue
             _make_asyncio_fixture_function(func)
             _inject_fixture_argnames(fixturedef)
-            if inspect.isasyncgenfunction(func):
-                fixturedef.func = _wrap_asyncgen(func)
-            elif inspect.iscoroutinefunction(func):
-                fixturedef.func = _wrap_async(func)
-
+            _synchronize_async_fixture(fixturedef)
             assert _is_asyncio_fixture_function(fixturedef.func)
             processed_fixturedefs.add(fixturedef)
 
@@ -216,6 +212,17 @@ def _inject_fixture_argnames(fixturedef: FixtureDef) -> None:
             to_add.append(name)
     if to_add:
         fixturedef.argnames += tuple(to_add)
+
+
+def _synchronize_async_fixture(fixturedef: FixtureDef) -> None:
+    """
+    Wraps the fixture function of an async fixture in a synchronous function.
+    """
+    func = fixturedef.func
+    if inspect.isasyncgenfunction(func):
+        fixturedef.func = _wrap_asyncgen(func)
+    elif inspect.iscoroutinefunction(func):
+        fixturedef.func = _wrap_async(func)
 
 
 def _add_kwargs(

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -178,12 +178,15 @@ def pytest_report_header(config: Config) -> List[str]:
     return [f"asyncio: mode={mode}"]
 
 
-def _preprocess_async_fixtures(config: Config, holder: Set[FixtureDef]) -> None:
+def _preprocess_async_fixtures(
+    config: Config,
+    processed_fixturedefs: Set[FixtureDef],
+) -> None:
     asyncio_mode = _get_asyncio_mode(config)
     fixturemanager = config.pluginmanager.get_plugin("funcmanage")
     for fixtures in fixturemanager._arg2fixturedefs.values():
         for fixturedef in fixtures:
-            if fixturedef in holder:
+            if fixturedef in processed_fixturedefs:
                 continue
             func = fixturedef.func
             if not _is_coroutine_or_asyncgen(func):
@@ -211,7 +214,7 @@ def _preprocess_async_fixtures(config: Config, holder: Set[FixtureDef]) -> None:
                 fixturedef.func = _wrap_async(func)
 
             assert _is_asyncio_fixture_function(fixturedef.func)
-            holder.add(fixturedef)
+            processed_fixturedefs.add(fixturedef)
 
 
 def _add_kwargs(

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -194,9 +194,8 @@ def _preprocess_async_fixtures(config: Config, holder: Set[FixtureDef]) -> None:
                     # Ignore async fixtures without explicit asyncio mark in strict mode
                     # This applies to pytest_trio fixtures, for example
                     continue
-                elif asyncio_mode == Mode.AUTO:
-                    # Enforce asyncio mode if 'auto'
-                    _make_asyncio_fixture_function(func)
+                # Enforce asyncio mode if 'auto'
+                _make_asyncio_fixture_function(func)
 
             to_add = []
             for name in ("request", "event_loop"):


### PR DESCRIPTION
Pytest-asyncio essentially performs custom collection logic in `pytest_pycollect_makeitem`. This PR splits up the handling of async fixtures and async tests during test collection, renames a couple of thins, and extracts more fine-grained functions from `_preprocess_async_fixtures`. The goal of this PR is to make the code easier to understand.

This is a result of my investigation into #204.