### PR TITLE
Do not warn about outdated pytest version when pytest>=7 is installed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+0.20.1 (22-10-21)
+=================
+- Fixes an issue that warned about using an old version of pytest, even though the most recent version was installed. `#430 <https://github.com/pytest-dev/pytest-asyncio/issues/430>`_
+
 0.20.0 (22-10-21)
 =================
 - BREAKING: Removed *legacy* mode. If you're upgrading from v0.19 and you haven't configured ``asyncio_mode = legacy``, you can upgrade without taking any additional action. If you're upgrading from an earlier version or you have explicitly enabled *legacy* mode, you need to switch to *auto* or *strict* mode before upgrading to this version.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -171,7 +171,7 @@ def pytest_configure(config: Config) -> None:
         "run using an asyncio event loop",
     )
 
-    if getattr(pytest, "__version_tuple__", (0, 0, 0) < (7,)):
+    if getattr(pytest, "version_tuple", (0, 0, 0)) < (7,):
         warnings.warn(
             "You're using an outdated version of pytest. Newer releases of "
             "pytest-asyncio will not be compatible with this pytest version. "

--- a/tests/test_pytest_min_version_warning.py
+++ b/tests/test_pytest_min_version_warning.py
@@ -1,0 +1,26 @@
+from textwrap import dedent
+
+import pytest
+
+
+@pytest.mark.skipif(
+    pytest.__version__ < "7.0.0",
+    reason="The warning shouldn't be present when run with recent pytest versions"
+)
+@pytest.mark.parametrize("mode", ("auto", "strict"))
+def test_pytest_min_version_warning_is_not_triggered_for_pytest_7(testdir, mode):
+    testdir.makepyfile(
+        dedent(
+            """\
+            import pytest
+
+            pytest_plugins = 'pytest_asyncio'
+
+            @pytest.mark.asyncio
+            async def test_triggers_pytest_warning():
+                pass
+            """
+        )
+    )
+    result = testdir.runpytest(f"--asyncio-mode={mode}")
+    result.assert_outcomes(passed=1, warnings=0)


### PR DESCRIPTION
This PR fixes an issue in the check for the pytest version. The changes prevent a warning about an outdated version of pytest to be emitted when the most recent version of pytest is installed.

Fixes #430.