### PR TITLE
Fix setuptools deprecation warning for license_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ long_description_content_type = text/x-rst
 author = Tin Tvrtković <tinchester@gmail.com>
 author_email = tinchester@gmail.com
 license = Apache 2.0
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
   Development Status :: 4 - Beta
 


### PR DESCRIPTION
Use `license_files` instead of `license_file` in `setup.py` to fix the following warning:

> The license_file parameter is deprecated, use license_files instead.