### PR TITLE
Bump to pytest 7.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+UNRELEASED
+=================
+- Replaced usage of deprecated ``@pytest.mark.tryfirst`` with ``@pytest.hookimpl(tryfirst=True)`` `#438 <https://github.com/pytest-dev/pytest-asyncio/pull/438>`_
+
 0.20.1 (22-10-21)
 =================
 - Fixes an issue that warned about using an old version of pytest, even though the most recent version was installed. `#430 <https://github.com/pytest-dev/pytest-asyncio/issues/430>`_

--- a/dependencies/default/constraints.txt
+++ b/dependencies/default/constraints.txt
@@ -1,6 +1,7 @@
 async-generator==1.10
 attrs==22.1.0
 coverage==6.5.0
+exceptiongroup==1.0.0
 flaky==3.7.0
 hypothesis==6.56.4
 idna==3.4
@@ -11,9 +12,8 @@ mypy-extensions==0.4.3
 outcome==1.2.0
 packaging==21.3
 pluggy==1.0.0
-py==1.11.0
 pyparsing==3.0.9
-pytest==7.1.3
+pytest==7.2.0
 pytest-trio==0.7.0
 sniffio==1.3.0
 sortedcontainers==2.4.0

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -180,7 +180,7 @@ def pytest_configure(config: Config) -> None:
         )
 
 
-@pytest.mark.tryfirst
+@pytest.hookimpl(tryfirst=True)
 def pytest_report_header(config: Config) -> List[str]:
     """Add asyncio config to pytest header."""
     mode = _get_asyncio_mode(config)
@@ -299,7 +299,7 @@ def _wrap_async(func: Callable[..., Awaitable[_R]]) -> Callable[..., _R]:
 _HOLDER: Set[FixtureDef] = set()
 
 
-@pytest.mark.tryfirst
+@pytest.hookimpl(tryfirst=True)
 def pytest_pycollect_makeitem(
         collector: Union[pytest.Module, pytest.Class], name: str, obj: object
 ) -> Union[

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -240,7 +240,6 @@ async def test_no_warning_on_skip():
 
 def test_async_close_loop(event_loop):
     event_loop.close()
-    return "ok"
 
 
 def test_warn_asyncio_marker_for_regular_func(testdir):


### PR DESCRIPTION
Pytest 7.2 introduces some deprecations which cause warnings when running the pytest-asyncio test suite.

Pytest now warns about the use of deprecated `@pytest.mark.tryfirst` and about tests that return a value different from `None`. The warnings were addressed accordingly so that the tests pass again.