### PR TITLE
Handle bound fixture methods correctly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 UNRELEASED
 =================
+- Fixes an issue with async fixtures that are defined as methods on a test class not being rebound to the actual test instance. `#197 <https://github.com/pytest-dev/pytest-asyncio/issues/197>`_
 - Replaced usage of deprecated ``@pytest.mark.tryfirst`` with ``@pytest.hookimpl(tryfirst=True)`` `#438 <https://github.com/pytest-dev/pytest-asyncio/pull/438>`_
 
 0.20.1 (22-10-21)

--- a/tests/async_fixtures/test_async_fixtures.py
+++ b/tests/async_fixtures/test_async_fixtures.py
@@ -23,3 +23,15 @@ async def test_async_fixture(async_fixture, mock):
     assert mock.call_count == 1
     assert mock.call_args_list[-1] == unittest.mock.call(START)
     assert async_fixture is RETVAL
+
+
+class TestAsyncFixtureMethod:
+    is_same_instance = False
+
+    @pytest.fixture(autouse=True)
+    async def async_fixture_method(self):
+        self.is_same_instance = True
+
+    @pytest.mark.asyncio
+    async def test_async_fixture_method(self):
+        assert self.is_same_instance

--- a/tests/async_fixtures/test_async_gen_fixtures.py
+++ b/tests/async_fixtures/test_async_gen_fixtures.py
@@ -36,3 +36,16 @@ async def test_async_gen_fixture_finalized(mock):
         assert mock.call_args_list[-1] == unittest.mock.call(END)
     finally:
         mock.reset_mock()
+
+
+class TestAsyncGenFixtureMethod:
+    is_same_instance = False
+
+    @pytest.fixture(autouse=True)
+    async def async_gen_fixture_method(self):
+        self.is_same_instance = True
+        yield None
+
+    @pytest.mark.asyncio
+    async def test_async_gen_fixture_method(self):
+        assert self.is_same_instance


### PR DESCRIPTION
When passed a _bound_ fixture method, re-bind that method to the currently active instance.

The implementation follows how [pytest handles bound fixtures](https://github.com/pytest-dev/pytest/blob/2f33ea87c8d303c3439655eb2bea24483bffde5e/src/_pytest/fixtures.py#L1086-L1110), including how it'll always bind any fixture when `fixturedef.unittest` is true, and otherwise only if the fixture wasn't already bound or if bound to a an instance of the same class or a subclass thereof.

Fixes #197
