### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,12 +10,11 @@ repos:
   hooks:
   - id: yesqa
 - repo: https://github.com/Zac-HD/shed
-  rev: 0.6.0     # 0.7 does not support Python 3.7
+  rev: 0.10.7
   hooks:
   - id: shed
     args:
     - --refactor
-    - --py37-plus
     types_or:
     - python
     - markdown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
     - -ignore
     - 'SC1004:'
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.9.1
+  rev: 0.19.2
   hooks:
   - id: check-github-actions
 ci:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
   hooks:
   - id: python-use-type-annotations
 - repo: https://github.com/rhysd/actionlint
-  rev: v1.6.8
+  rev: v1.6.22
   hooks:
   - id: actionlint-docker
     args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,8 +37,8 @@ repos:
   - id: check-xml
   - id: check-yaml
   - id: debug-statements
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/pycqa/flake8
+  rev: 5.0.4
   hooks:
   - id: flake8
     language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.3.0
   hooks:
   - id: check-merge-conflict
     exclude: rst$
@@ -26,7 +26,7 @@ repos:
   - id: yamlfmt
     args: [--mapping, '2', --sequence, '2', --offset, '0']
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.3.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     - markdown
     - rst
 - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-  rev: 0.1.1
+  rev: 0.2.2
   hooks:
   - id: yamlfmt
     args: [--mapping, '2', --sequence, '2', --offset, '0']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - id: check-merge-conflict
     exclude: rst$
 - repo: https://github.com/asottile/yesqa
-  rev: v1.3.0
+  rev: v1.4.0
   hooks:
   - id: yesqa
 - repo: https://github.com/Zac-HD/shed

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -25,7 +25,7 @@ from typing import (
 )
 
 import pytest
-from pytest import Function, Session, Item
+from pytest import Function, Item, Session
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -89,11 +89,10 @@ def fixture(
     scope: "Union[_ScopeName, Callable[[str, Config], _ScopeName]]" = ...,
     params: Optional[Iterable[object]] = ...,
     autouse: bool = ...,
-    ids: Optional[
-        Union[
-            Iterable[Union[None, str, float, int, bool]],
-            Callable[[Any], Optional[object]],
-        ]
+    ids: Union[
+        Iterable[Union[str, float, int, bool, None]],
+        Callable[[Any], Optional[object]],
+        None,
     ] = ...,
     name: Optional[str] = ...,
 ) -> FixtureFunction:
@@ -107,11 +106,10 @@ def fixture(
     scope: "Union[_ScopeName, Callable[[str, Config], _ScopeName]]" = ...,
     params: Optional[Iterable[object]] = ...,
     autouse: bool = ...,
-    ids: Optional[
-        Union[
-            Iterable[Union[None, str, float, int, bool]],
-            Callable[[Any], Optional[object]],
-        ]
+    ids: Union[
+        Iterable[Union[str, float, int, bool, None]],
+        Callable[[Any], Optional[object]],
+        None,
     ] = ...,
     name: Optional[str] = None,
 ) -> FixtureFunctionMarker:
@@ -330,9 +328,9 @@ _HOLDER: Set[FixtureDef] = set()
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_pycollect_makeitem(
-        collector: Union[pytest.Module, pytest.Class], name: str, obj: object
+    collector: Union[pytest.Module, pytest.Class], name: str, obj: object
 ) -> Union[
-    None, pytest.Item, pytest.Collector, List[Union[pytest.Item, pytest.Collector]]
+    pytest.Item, pytest.Collector, List[Union[pytest.Item, pytest.Collector]], None
 ]:
     """A pytest hook to collect asyncio coroutines."""
     if not collector.funcnamefilter(name):

--- a/tests/test_pytest_min_version_warning.py
+++ b/tests/test_pytest_min_version_warning.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.mark.skipif(
     pytest.__version__ < "7.0.0",
-    reason="The warning shouldn't be present when run with recent pytest versions"
+    reason="The warning shouldn't be present when run with recent pytest versions",
 )
 @pytest.mark.parametrize("mode", ("auto", "strict"))
 def test_pytest_min_version_warning_is_not_triggered_for_pytest_7(testdir, mode):


### PR DESCRIPTION
This PR updates all pre-commit hooks to the most recent versions.

This fixes an issue that causes the CI pipeline to fail, due to the move of flake8 from GitLab to GitHub and the subsequent URL change (see https://github.com/PyCQA/flake8/pull/1305).

The update of shed causes changes in the ordering of some Union types. These should not break anything, though.