### PR TITLE
[fix] Prevent DeprecationWarning about existing event loops to bubble up into user code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+0.20.3 (22-12-08)
+=================
+- Prevent DeprecationWarning to bubble up on CPython 3.10.9 and 3.11.1.
+  `#460 <https://github.com/pytest-dev/pytest-asyncio/issues/460>`_
+
 0.20.2 (22-11-11)
 =================
 - Fixes an issue with async fixtures that are defined as methods on a test class not being rebound to the actual test instance. `#197 <https://github.com/pytest-dev/pytest-asyncio/issues/197>`_

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -401,7 +401,9 @@ def pytest_fixture_setup(
         loop = outcome.get_result()
         policy = asyncio.get_event_loop_policy()
         try:
-            old_loop = policy.get_event_loop()
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                old_loop = policy.get_event_loop()
             if old_loop is not loop:
                 old_loop.close()
         except RuntimeError:


### PR DESCRIPTION
Pytest-asyncio fixture setup currently uses `get_event_loop` to clean up loops that don't correspond to the loop returned by the `event_loop` fixture. Starting with CPython 3.10.9 and 3.11.1 the call to get_event_loop emits a DeprecationWarning when function is called, but no event loop exists. This warning bubbles up and shows in test runs of library users. If the users have enabled `-W error` their tests will fail due to a warning in pytest-asyncio.

This patch ignores the DeprecationWarning in the fixture setup. This is a temporary solution to restore compatibility with the respective CPython patch releases.

Addresses #460