### PR TITLE
Fix Python 3.11 CI environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 3.11-dev]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -52,5 +52,5 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11-dev: py311
+    3.11: py311
     pypy3: pypy3


### PR DESCRIPTION
Python 3.11 has been released. The pipeline currently uses the `3.11-dev` environment, which is no longer available. As a result  the CI build for CPython 3.11 is skipped.