### PR TITLE
Combine coverage data for all interpreter versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,9 +74,12 @@ jobs:
     - name: Run tox targets for ${{ matrix.python-version }}
       run: python -m tox
 
-    - name: Prepare coverage artifact
+    - name: Store coverage data
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-per-interpreter
+        path: .coverage.*
       if: ${{ contains(env.USING_COVERAGE, matrix.python-version) }}
-      uses: aio-libs/prepare-coverage@v21.9.1
 
   check:
     name: Check
@@ -88,8 +91,27 @@ jobs:
       uses: re-actors/alls-green@release/v1
       with:
         jobs: ${{ toJSON(needs) }}
-    - name: Upload coverage
-      uses: aio-libs/upload-coverage@v21.9.4
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+    - name: Install Coverage.py
+      run: |
+        set -xe
+        python -m pip install --upgrade coverage[toml]
+    - name: Download coverage data for all test runs
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage-per-interpreter
+    - name: Combine coverage data and create report
+      run: |
+        coverage combine
+        coverage xml
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v3
+      with:
+        files: coverage.xml
+        fail_ci_if_error: true
 
   deploy:
     name: Deploy

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,7 @@ endif
 	python -m mypy pytest_asyncio
 
 test:
-	coverage run -m pytest tests
-	coverage xml
-	coverage report
+	coverage run --parallel-mode -m pytest tests
 
 install:
 	pip install -U pre-commit

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 	python -m mypy pytest_asyncio
 
 test:
-	coverage run --parallel-mode -m pytest tests
+	coverage run --parallel-mode --omit */_version.py -m pytest tests
 
 install:
 	pip install -U pre-commit

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifdef CI
 else
 	python -m pre_commit run --all-files
 endif
-	python -m mypy pytest_asyncio --show-error-codes
+	python -m mypy pytest_asyncio
 
 test:
 	coverage run -m pytest tests

--- a/tox.ini
+++ b/tox.ini
@@ -33,13 +33,6 @@ commands =
 allowlist_externals =
     make
 
-[testenv:coverage-report]
-deps = coverage
-skip_install = true
-commands =
-    coverage combine
-    coverage report
-
 [testenv:version-info]
 deps =
     packaging == 21.3


### PR DESCRIPTION
Some code in pytest-asyncio is specific to certain versions of the Python interpreter. Therefore, the code coverage can be different for tests runs with different interpreters. Currently, the CI pipeline does not accommodate this fact.

This PR changes coverage data to be generated by each CI environment during the test runs. The different coverage results are combined in the check step just before uploading them to codecov.

The obsolete tox environment "coverage-report" has been removed.

The mypy command line option `--show-error-codes` has been removed, as showing error codes [is the default behavior](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-hide-error-codes).

This change addresses some of the deprecation warnings in the CI described in #429.