### PR TITLE
Remove use of deprecated ::set-output GitHub command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,9 +38,11 @@ jobs:
       run: check-wheel-contents dist/*.whl
     - name: Check long_description
       run: python -m twine check dist/*
+    - name: Install pytest-asyncio
+      run: pip install .
     - name: Get version info
       id: version
-      run: tox -qq -e version-info >> $GITHUB_OUTPUT
+      run: python ./tools/get-version.py >> $GITHUB_OUTPUT
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       run: python -m twine check dist/*
     - name: Get version info
       id: version
-      run: tox -e version-info
+      run: tox -qq -e version-info >> $GITHUB_OUTPUT
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/tools/get-version.py
+++ b/tools/get-version.py
@@ -8,9 +8,9 @@ from packaging.version import parse as parse_version
 def main():
     version_string = metadata.version("pytest-asyncio")
     version = parse_version(version_string)
-    print(f"::set-output name=version::{version}")
+    print(f"version={version}")
     prerelease = json.dumps(version.is_prerelease)
-    print(f"::set-output name=prerelease::{prerelease}")
+    print(f"prerelease={prerelease}")
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.14.0
-envlist = py37, py38, py39, py310, py311, lint, version-info, pytest-min
+envlist = py37, py38, py39, py310, py311, lint, pytest-min
 isolated_build = true
 passenv =
     CI
@@ -32,12 +32,6 @@ commands =
     make lint
 allowlist_externals =
     make
-
-[testenv:version-info]
-deps =
-    packaging == 21.3
-commands =
-    python ./tools/get-version.py
 
 [gh-actions]
 python =


### PR DESCRIPTION
The ::set-output command has been deprecated in favor of redirecting the output to a file. [0]

This patch adjusts _get-version.py_ to the new output syntax.
Unfortunately, `tox -qq` is no longer able to silences the summary output. Therefore, the get-version script is executed directly in the environment on the pipeline right after pytest-asyncio is installed.

[0] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Closes #429