### PR TITLE
Add mypy as pre-commit hook

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,8 +57,6 @@ jobs:
   test:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    env:
-      USING_COVERAGE: 3.7,3.8,3.9,3.10,3.11
 
     strategy:
       matrix:
@@ -84,7 +82,6 @@ jobs:
       with:
         name: coverage-per-interpreter
         path: .coverage.*
-      if: ${{ contains(env.USING_COVERAGE, matrix.python-version) }}
 
   check:
     name: Check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,8 +133,6 @@ jobs:
         sudo apt-get install -y pandoc
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Download distributions
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,12 +26,14 @@ jobs:
     - name: Install GitHub matcher for ActionLint checker
       run: |
         echo "::add-matcher::.github/actionlint-matcher.json"
+    - name: Install pre-commit
+      run: python -m pip install pre-commit
+    - name: Run pre-commit checks
+      run: pre-commit run --all-files --show-diff-on-failure
     - name: Install check-wheel-content, and twine
       run: python -m pip install build check-wheel-contents tox twine
     - name: Build package
       run: python -m build
-    - name: Run tox for linter
-      run: python -m tox -e lint
     - name: List result
       run: ls -l dist
     - name: Check wheel contents

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
     branches: [master]
   workflow_dispatch:
 
+env:
+  PYTHON_LATEST: 3.11
+
 jobs:
   lint:
     name: Run linters
@@ -22,7 +25,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: ${{ env.PYTHON_LATEST }}
     - name: Install GitHub matcher for ActionLint checker
       run: |
         echo "::add-matcher::.github/actionlint-matcher.json"
@@ -98,7 +101,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: ${{ env.PYTHON_LATEST }}
     - name: Install Coverage.py
       run: |
         set -xe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: 3.11
     - name: Install GitHub matcher for ActionLint checker
       run: |
         echo "::add-matcher::.github/actionlint-matcher.json"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,11 @@ repos:
   - id: check-xml
   - id: check-yaml
   - id: debug-statements
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.991
+  hooks:
+  - id: mypy
+    exclude: ^(docs|tests)/.*
 - repo: https://github.com/pycqa/flake8
   rev: 5.0.4
   hooks:

--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,6 @@ clean-test: ## remove test and coverage artifacts
 	rm -f .coverage
 	rm -fr htmlcov/
 
-lint:
-# CI env-var is set by GitHub actions
-ifdef CI
-	python -m pre_commit run --all-files --show-diff-on-failure
-else
-	python -m pre_commit run --all-files
-endif
-	python -m mypy pytest_asyncio
-
 test:
 	coverage run --parallel-mode --omit */_version.py -m pytest tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.14.0
-envlist = py37, py38, py39, py310, py311, lint, pytest-min
+envlist = py37, py38, py39, py310, py311, pytest-min
 isolated_build = true
 passenv =
     CI
@@ -20,16 +20,6 @@ deps =
      --requirement dependencies/pytest-min/requirements.txt
      --constraint dependencies/pytest-min/constraints.txt
 commands = make test
-allowlist_externals =
-    make
-
-[testenv:lint]
-basepython = python3.10
-extras = testing
-deps =
-    pre-commit == 2.16.0
-commands =
-    make lint
 allowlist_externals =
     make
 


### PR DESCRIPTION
This changeset adds mypy as a pre-commit hook. As a result, the pipeline can simply run pre-commit and we can get rid of the `make lint` target and the `tox -e lint` environment.

This patch also contains a couple of clean-ups to the CI pipeline.