### PR TITLE
Fail CI run when the corresponding Python environment cannot be found

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 3.11-dev]
 
     steps:
     - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,6 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py311
+    3.11-dev: py311
     pypy3: pypy3
 fail_on_no_env = True

--- a/tox.ini
+++ b/tox.ini
@@ -31,3 +31,4 @@ python =
     3.10: py310
     3.11: py311
     pypy3: pypy3
+fail_on_no_env = True


### PR DESCRIPTION
This avoids successful CI runs for Python environment which never actually execute test code. One example where this happened in the past was addressed in commit 25d9592286682bc6dbfbf291028ff7a9594cf283.
