### PR TITLE
Add documentation link after migration to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ pytest-asyncio
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black
 
-pytest-asyncio is a `pytest <https://docs.pytest.org/en/latest/contents.html>`_ plugin. It facilitates testing of code that uses the `asyncio <https://docs.python.org/3/library/asyncio.html>`_ library.
+`pytest-asyncio <https://pytest-asyncio.readthedocs.io/en/latest/>`_ is a `pytest <https://docs.pytest.org/en/latest/contents.html>`_ plugin. It facilitates testing of code that uses the `asyncio <https://docs.python.org/3/library/asyncio.html>`_ library.
 
 Specifically, pytest-asyncio provides support for coroutines as test functions. This allows users to *await* code inside their tests. For example, the following code is executed as a test item by pytest:
 
@@ -24,6 +24,7 @@ Specifically, pytest-asyncio provides support for coroutines as test functions. 
         res = await library.do_something()
         assert b"expected result" == res
 
+More details can be found in the `documentation <https://pytest-asyncio.readthedocs.io/en/latest/>`_.
 
 Note that test classes subclassing the standard `unittest <https://docs.python.org/3/library/unittest.html>`__ library are not supported. Users
 are advised to use `unittest.IsolatedAsyncioTestCase <https://docs.python.org/3/library/unittest.html#unittest.IsolatedAsyncioTestCase>`__


### PR DESCRIPTION
The README doesn't provide an easy way to find the docs :)