### PR TITLE
Deprecate closing of existing loops

### DIFF
--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -5,7 +5,10 @@ Changelog
 UNRELEASED
 =================
 - Drop compatibility with pytest 6.1. Pytest-asyncio now depends on pytest 7.0 or newer.
-- event_loop fixture teardown emits a ResourceWarning when the current event loop has not been closed.
+- pytest-asyncio cleans up any stale event loops when setting up and tearing down the
+  event_loop fixture. This behavior has been deprecated and pytest-asyncio emits a
+  DeprecationWarning when tearing down the event_loop fixture and current event loop
+  has not been closed.
 
 0.20.3 (22-12-08)
 =================

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -397,7 +397,9 @@ def pytest_fixture_setup(
             if old_loop is not loop:
                 old_loop.close()
         except RuntimeError:
-            # Swallow this, since it's probably bad event loop hygiene.
+            # Either the current event loop has been set to None
+            # or the loop policy doesn't specify to create new loops
+            # or we're not in the main thread
             pass
         policy.set_event_loop(loop)
         return


### PR DESCRIPTION
`asyncio.get_event_loop()` will effectively become an alias to `asyncio.get_running_loop()` in future Python versions. [0] As a result, pytest-asyncio will no longer be able to retrieve the current loop and close it for the user.

This PR raises a deprecation warning when the event_loop fixture is torn down and the current loop is unclosed. This will hopefully nudge users towards correct event loop handling and prevent breakage of their tests when pytest-asyncio removes the use of get_event_loop().

I think the [previous PR](https://github.com/pytest-dev/pytest-asyncio/pull/492) didn't go far enough with emitting a ResourceWarning, because ResourceWarnings are not displayed by default.

[0] [Deprecate get_event_loop()](https://github.com/python/cpython/issues/83710)