### PR TITLE
Tests are run against Python 3.12 (dev)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,11 +60,16 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 3.12-dev]
 
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      if: "!endsWith(matrix.python-version, '-dev')"
+      with:
+        python-version: ${{ matrix.python-version }}
+    - uses: deadsnakes/action@v3.0.0
+      if: endsWith(matrix.python-version, '-dev')
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.14.0
-envlist = py37, py38, py39, py310, py311, pytest-min
+envlist = py37, py38, py39, py310, py311, py312, pytest-min
 isolated_build = true
 passenv =
     CI
@@ -30,4 +30,5 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
     pypy3: pypy3


### PR DESCRIPTION
This should make any incompatibilities visible earlier which, in turn, gives pytest-asyncio more time to adjust and react.

Closes #512 