### PR TITLE
Improve output with invalid asyncio_mode

### DIFF
--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+0.22.0 (UNRELEASED)
+===================
+- Output a proper error message when an invalid ``asyncio_mode`` is selected.
+
 0.21.0 (2023-03-19)
 ===================
 - Drop compatibility with pytest 6.1. Pytest-asyncio now depends on pytest 7.0 or newer.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -164,7 +164,13 @@ def _get_asyncio_mode(config: Config) -> Mode:
     val = config.getoption("asyncio_mode")
     if val is None:
         val = config.getini("asyncio_mode")
-    return Mode(val)
+    try:
+        return Mode(val)
+    except ValueError:
+        modes = ", ".join(m.value for m in Mode)
+        raise pytest.UsageError(
+            f"{val!r} is not a valid asyncio_mode. Valid modes: {modes}."
+        )
 
 
 def pytest_configure(config: Config) -> None:

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -272,3 +272,11 @@ def test_warn_asyncio_marker_for_regular_func(testdir):
     result.stdout.fnmatch_lines(
         ["*is marked with '@pytest.mark.asyncio' but it is not an async function.*"]
     )
+
+
+def test_invalid_asyncio_mode(testdir):
+    result = testdir.runpytest("-o", "asyncio_mode=True")
+    result.stderr.no_fnmatch_line("INTERNALERROR> *")
+    result.stderr.fnmatch_lines(
+        "ERROR: 'True' is not a valid asyncio_mode. Valid modes: auto, strict."
+    )


### PR DESCRIPTION
Instead of a long INTERNALERROR> stack trace, output a proper error
message:

    $ pytest -o asyncio_mode=True
    =================== test session starts ====================
    platform linux -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0
    ERROR: 'True' is not a valid asyncio_mode

See https://github.com/pytest-dev/pytest/issues/11083
