### PR TITLE
Ignore ast deprecation warnings on Python 3.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,10 @@ addopts = -rsx --tb=short
 testpaths = tests
 asyncio_mode = auto
 junit_family=xunit2
-filterwarnings = error
-
+filterwarnings =
+  error
+  # https://github.com/pytest-dev/pytest/issues/10977
+  ignore:ast\.(Num|NameConstant|Str).*:DeprecationWarning:_pytest
+  ignore:Attribute s is deprecated.*:DeprecationWarning:_pytest
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Fixes the CI run for Python 3.12 until https://github.com/pytest-dev/pytest/issues/10977 is addressed in a release.