### PR TITLE
package py.typed into the distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,9 @@ docs =
 pytest11 =
     asyncio = pytest_asyncio.plugin
 
+[options.package_data]
+pytest_asyncio = py.typed
+
 [coverage:run]
 source = pytest_asyncio
 branch = true


### PR DESCRIPTION
It's unfortunate that this isn't the default in setuptools...