### PR TITLE
Remove obsolete warning filters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,8 +72,6 @@ asyncio_mode = auto
 junit_family=xunit2
 filterwarnings =
   error
-  # https://github.com/pytest-dev/pytest/issues/10977
-  ignore:ast\.(Num|NameConstant|Str).*:DeprecationWarning:_pytest
-  ignore:Attribute s is deprecated.*:DeprecationWarning:_pytest
+
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
The issue has been addressed in pytest 7.4.0.