### PR TITLE
All tests return "success" when they are successful

### DIFF
--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 - Output a proper error message when an invalid ``asyncio_mode`` is selected.
 - Extend warning message about unclosed event loops with additional possible cause.
   `#531 <https://github.com/pytest-dev/pytest-asyncio/issues/531>`_
+- Previously, some tests reported "skipped" or "xfailed" as a result. Now all tests report a "success" results.
 
 0.21.0 (2023-03-19)
 ===================

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -3,6 +3,7 @@ import asyncio
 from textwrap import dedent
 
 import pytest
+from pytest import Pytester
 
 import pytest_asyncio.plugin
 
@@ -25,10 +26,23 @@ async def test_asyncio_marker():
     await asyncio.sleep(0)
 
 
-@pytest.mark.xfail(reason="need a failure", strict=True)
-@pytest.mark.asyncio
-async def test_asyncio_marker_fail():
-    raise AssertionError
+def test_asyncio_marker_compatibility_with_xfail(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+                import pytest
+
+                pytest_plugins = "pytest_asyncio"
+
+                @pytest.mark.xfail(reason="need a failure", strict=True)
+                @pytest.mark.asyncio
+                async def test_asyncio_marker_fail():
+                    raise AssertionError
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(xfailed=1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -265,9 +265,22 @@ class TestEventLoopStartedBeforeFixtures:
         assert await loop.run_in_executor(None, self.foo) == 1
 
 
-@pytest.mark.asyncio
-async def test_no_warning_on_skip():
-    pytest.skip("Test a skip error inside asyncio")
+def test_asyncio_marker_compatibility_with_skip(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+                import pytest
+
+                pytest_plugins = "pytest_asyncio"
+
+                @pytest.mark.asyncio
+                async def test_no_warning_on_skip():
+                    pytest.skip("Test a skip error inside asyncio")
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(skipped=1)
 
 
 def test_async_close_loop(event_loop):

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -283,6 +283,23 @@ def test_asyncio_marker_compatibility_with_skip(pytester: Pytester):
     result.assert_outcomes(skipped=1)
 
 
+def test_asyncio_auto_mode_compatibility_with_skip(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+                import pytest
+
+                pytest_plugins = "pytest_asyncio"
+
+                async def test_no_warning_on_skip():
+                    pytest.skip("Test a skip error inside asyncio")
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=auto")
+    result.assert_outcomes(skipped=1)
+
+
 def test_async_close_loop(event_loop):
     event_loop.close()
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -45,6 +45,24 @@ def test_asyncio_marker_compatibility_with_xfail(pytester: Pytester):
     result.assert_outcomes(xfailed=1)
 
 
+def test_asyncio_auto_mode_compatibility_with_xfail(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+                import pytest
+
+                pytest_plugins = "pytest_asyncio"
+
+                @pytest.mark.xfail(reason="need a failure", strict=True)
+                async def test_asyncio_marker_fail():
+                    raise AssertionError
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=auto")
+    result.assert_outcomes(xfailed=1)
+
+
 @pytest.mark.asyncio
 async def test_asyncio_marker_with_default_param(a_param=None):
     """Test the asyncio pytest marker."""

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -300,10 +300,6 @@ def test_asyncio_auto_mode_compatibility_with_skip(pytester: Pytester):
     result.assert_outcomes(skipped=1)
 
 
-def test_async_close_loop(event_loop):
-    event_loop.close()
-
-
 def test_warn_asyncio_marker_for_regular_func(testdir):
     testdir.makepyfile(
         dedent(


### PR DESCRIPTION
Previously, there have been some tests that try to assert compatibility with pytest.mark.xfail or pytest.skip. Those tests reported "xfailed" or "skipped" in the test suite.

This creates extra work for downstream packagers of pytest-asyncio if they want to run the unit test suite as part of the installation process.

This MR changes the tests to return "success" when they are successful. More specifically, the tests were changed to run  inside Pytester.

The test suite was also extended to test the corresponding behaviors in *auto* mode.
One unnecessary test case was removed.