### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 3.12-dev]
+        python-version: ['3.8', '3.9', '3.10', '3.11', 3.12-dev]
 
     steps:
     - uses: actions/checkout@v3

--- a/dependencies/default/constraints.txt
+++ b/dependencies/default/constraints.txt
@@ -20,5 +20,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 trio==0.22.1
 typed-ast==1.5.5
-typing_extensions==4.7.1
 zipp==3.15.0

--- a/dependencies/default/requirements.txt
+++ b/dependencies/default/requirements.txt
@@ -1,4 +1,3 @@
 # Always adjust install_requires in setup.cfg and pytest-min-requirements.txt
 # when changing runtime dependencies
 pytest >= 7.0.0
-typing-extensions >= 3.7.2; python_version < "3.8"

--- a/dependencies/pytest-min/requirements.txt
+++ b/dependencies/pytest-min/requirements.txt
@@ -1,4 +1,3 @@
 # Always adjust install_requires in setup.cfg and requirements.txt
 # when changing minimum version dependencies
 pytest[testing] == 7.0.0
-typing-extensions >= 3.7.2; python_version < "3.8"

--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+1.0.0 (UNRELEASED)
+==================
+- Remove support for Python 3.7
+
 0.21.1 (2023-07-12)
 ===================
 - Output a proper error message when an invalid ``asyncio_mode`` is selected.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -5,7 +5,6 @@ import enum
 import functools
 import inspect
 import socket
-import sys
 import warnings
 from textwrap import dedent
 from typing import (
@@ -17,6 +16,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
     Optional,
     Set,
     TypeVar,
@@ -35,11 +35,6 @@ from pytest import (
     PytestPluginManager,
     Session,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 _R = TypeVar("_R")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
 
   License :: OSI Approved :: Apache Software License
 
-  Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
@@ -34,14 +33,13 @@ classifiers =
   Typing :: Typed
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find:
 include_package_data = True
 
 # Always adjust requirements.txt and pytest-min-requirements.txt when changing runtime dependencies
 install_requires =
   pytest >= 7.0.0
-  typing-extensions >= 3.7.2; python_version < "3.8"
 
 [options.extras_require]
 testing =

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -15,18 +15,6 @@ if sys.platform == "win32":
         loop.close()
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 8),
-    reason="""
-        When run with Python 3.7 asyncio.subprocess.create_subprocess_exec seems to be
-        affected by an issue that prevents correct cleanup. Tests using pytest-trio
-        will report that signal handling is already performed by another library and
-        fail. [1] This is possibly a bug in CPython 3.7, so we ignore this test for
-        that Python version.
-
-        [1] https://github.com/python-trio/pytest-trio/issues/126
-    """,
-)
 @pytest.mark.asyncio
 async def test_subprocess(event_loop):
     """Starting a subprocess should be possible."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.14.0
-envlist = py37, py38, py39, py310, py311, py312, pytest-min
+envlist = py38, py39, py310, py311, py312, pytest-min
 isolated_build = true
 passenv =
     CI
@@ -25,8 +25,7 @@ allowlist_externals =
 
 [gh-actions]
 python =
-    3.7: py37, pytest-min
-    3.8: py38
+    3.8: py38, pytest-min
     3.9: py39
     3.10: py310
     3.11: py311


### PR DESCRIPTION
We should do a release with the existing fixes and improvements (see other MRs) before dropping Python 3.7 support.