### PR TITLE
Fix incorrect event loop fixture override warnings

### DIFF
--- a/tests/test_event_loop_fixture_finalizer.py
+++ b/tests/test_event_loop_fixture_finalizer.py
@@ -133,5 +133,5 @@ def test_event_loop_fixture_finalizer_raises_warning_when_test_leaves_loop_unclo
         )
     )
     result = pytester.runpytest("--asyncio-mode=strict", "-W", "default")
-    result.assert_outcomes(passed=1, warnings=2)
+    result.assert_outcomes(passed=1, warnings=1)
     result.stdout.fnmatch_lines("*unclosed event loop*")


### PR DESCRIPTION
The existing code relies on the `__original_func` attribute to be _true_ on `FixtureDef.func`. For some reason, this is not always the case, even though the event_loop fixture sets the attribute in the function body.

This PR changes the warning to be triggered when the signature of the test function contains the `event_loop` argument, in which case the problem seems to go away..