### PR TITLE
Fix internal error with module level skips

### DIFF
--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+0.22.1 (UNRELEASED)
+===================
+- Fixes a bug that caused an internal pytest error when using module-level skips `#655 <https://github.com/pytest-dev/pytest-asyncio/pull/655>`_
+
+
 0.22.0 (2023-10-31)
 ===================
 - Class-scoped and module-scoped event loops can be requested

--- a/tests/test_pytest_skip.py
+++ b/tests/test_pytest_skip.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 from pytest import Pytester
 
 
-def test_asyncio_marker_compatibility_with_skip(pytester: Pytester):
+def test_asyncio_strict_mode_skip(pytester: Pytester):
     pytester.makepyfile(
         dedent(
             """\
@@ -21,7 +21,7 @@ def test_asyncio_marker_compatibility_with_skip(pytester: Pytester):
     result.assert_outcomes(skipped=1)
 
 
-def test_asyncio_auto_mode_compatibility_with_skip(pytester: Pytester):
+def test_asyncio_auto_mode_skip(pytester: Pytester):
     pytester.makepyfile(
         dedent(
             """\
@@ -36,3 +36,55 @@ def test_asyncio_auto_mode_compatibility_with_skip(pytester: Pytester):
     )
     result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(skipped=1)
+
+
+def test_asyncio_strict_mode_module_level_skip(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+                import pytest
+
+                pytest.skip("Skip all tests", allow_module_level=True)
+
+                @pytest.mark.asyncio
+                async def test_is_skipped():
+                    pass
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(skipped=1)
+
+
+def test_asyncio_auto_mode_module_level_skip(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+                import pytest
+
+                pytest.skip("Skip all tests", allow_module_level=True)
+
+                async def test_is_skipped():
+                    pass
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=auto")
+    result.assert_outcomes(skipped=1)
+
+
+def test_asyncio_auto_mode_wrong_skip_usage(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+                import pytest
+
+                pytest.skip("Skip all tests")
+
+                async def test_is_skipped():
+                    pass
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=auto")
+    result.assert_outcomes(errors=1)

--- a/tests/test_pytest_skip.py
+++ b/tests/test_pytest_skip.py
@@ -1,0 +1,38 @@
+from textwrap import dedent
+
+from pytest import Pytester
+
+
+def test_asyncio_marker_compatibility_with_skip(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+                import pytest
+
+                pytest_plugins = "pytest_asyncio"
+
+                @pytest.mark.asyncio
+                async def test_no_warning_on_skip():
+                    pytest.skip("Test a skip error inside asyncio")
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(skipped=1)
+
+
+def test_asyncio_auto_mode_compatibility_with_skip(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+                import pytest
+
+                pytest_plugins = "pytest_asyncio"
+
+                async def test_no_warning_on_skip():
+                    pytest.skip("Test a skip error inside asyncio")
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=auto")
+    result.assert_outcomes(skipped=1)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -260,41 +260,6 @@ class TestEventLoopStartedBeforeFixtures:
         assert await loop.run_in_executor(None, self.foo) == 1
 
 
-def test_asyncio_marker_compatibility_with_skip(pytester: Pytester):
-    pytester.makepyfile(
-        dedent(
-            """\
-                import pytest
-
-                pytest_plugins = "pytest_asyncio"
-
-                @pytest.mark.asyncio
-                async def test_no_warning_on_skip():
-                    pytest.skip("Test a skip error inside asyncio")
-            """
-        )
-    )
-    result = pytester.runpytest("--asyncio-mode=strict")
-    result.assert_outcomes(skipped=1)
-
-
-def test_asyncio_auto_mode_compatibility_with_skip(pytester: Pytester):
-    pytester.makepyfile(
-        dedent(
-            """\
-                import pytest
-
-                pytest_plugins = "pytest_asyncio"
-
-                async def test_no_warning_on_skip():
-                    pytest.skip("Test a skip error inside asyncio")
-            """
-        )
-    )
-    result = pytester.runpytest("--asyncio-mode=auto")
-    result.assert_outcomes(skipped=1)
-
-
 def test_invalid_asyncio_mode(testdir):
     result = testdir.runpytest("-o", "asyncio_mode=True")
     result.stderr.no_fnmatch_line("INTERNALERROR> *")


### PR DESCRIPTION
This PR wraps the call to `_pytest.mark.structures.get_unpacked_marks` in a try except that handles exceptions raised by pytest related to test outcomes, i.e. `pytest.skip(..., allow_module_level=True)`, or collection errors, e.g. bare `pytest.skip(...)`.

This is a bit of a bandaid. The best solution would be to not used `get_unpacked_marks` at all, or at least call it as part of the test collection phase.

Fixes #655 