### PR TITLE
Restore compatibility with pytest>=7.0,<7.2

### DIFF
--- a/dependencies/pytest-min/constraints.txt
+++ b/dependencies/pytest-min/constraints.txt
@@ -18,5 +18,6 @@ pytest==7.0.0
 requests==2.28.1
 sortedcontainers==2.4.0
 tomli==2.0.1
+trio==0.21.0
 urllib3==1.26.12
 xmlschema==2.1.1

--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+0.22.1 (UNRELEASED)
+===================
+- Fixes a bug that broke compatibility with pytest>=7.0,<7.2. `#654 <https://github.com/pytest-dev/pytest-asyncio/pull/654>`_
+
 0.22.0 (2023-10-31)
 ===================
 - Class-scoped and module-scoped event loops can be requested

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -549,7 +549,7 @@ def pytest_collectstart(collector: pytest.Collector):
         return
     # pytest.Collector.own_markers is empty at this point,
     # so we rely on _pytest.mark.structures.get_unpacked_marks
-    marks = get_unpacked_marks(collector.obj, consider_mro=True)
+    marks = get_unpacked_marks(collector.obj)
     for mark in marks:
         if not mark.name == "asyncio_event_loop":
             continue

--- a/tox.ini
+++ b/tox.ini
@@ -7,18 +7,20 @@ passenv =
 
 [testenv]
 extras = testing
-deps =
-     --requirement dependencies/default/requirements.txt
-     --constraint dependencies/default/constraints.txt
+install_command = python -m pip install \
+    --requirement dependencies/default/requirements.txt \
+    --constraint dependencies/default/constraints.txt \
+    {opts} {packages}
 commands = make test
 allowlist_externals =
     make
 
 [testenv:pytest-min]
 extras = testing
-deps =
-     --requirement dependencies/pytest-min/requirements.txt
-     --constraint dependencies/pytest-min/constraints.txt
+install_command = python -m pip install \
+    --requirement dependencies/pytest-min/requirements.txt \
+    --constraint dependencies/pytest-min/constraints.txt \
+    {opts} {packages}
 commands = make test
 allowlist_externals =
     make


### PR DESCRIPTION
Pytest-asyncio v0.22.0 makes use of `_pytest.mark.structures.get_unpacked_marks`. It explicitly passes the `consider_mro` keyword argument which has only been added in pytest v7.2. This lead to breakage for users of with pytest>=7.0,<7.2.
The error has not been uncovered by the test suite, due to wrong configuration of the _pytest-min_ tox environment.

This PR fixes the pytest-min test environment, adjusts the pinned dependencies for this environment, and issues the call to `get_unpacked_marks` in a way that is backwards compatible with older pytest versions.

Fixes #654 