### PR TITLE
Introduce event_loop_policy fixture

### DIFF
--- a/docs/source/how-to-guides/index.rst
+++ b/docs/source/how-to-guides/index.rst
@@ -5,6 +5,7 @@ How-To Guides
 .. toctree::
   :hidden:
 
+  multiple_loops
   uvloop
 
 This section of the documentation provides code snippets and recipes to accomplish specific tasks with pytest-asyncio.

--- a/docs/source/how-to-guides/multiple_loops.rst
+++ b/docs/source/how-to-guides/multiple_loops.rst
@@ -1,0 +1,10 @@
+======================================
+How to test with different event loops
+======================================
+
+Parametrizing the *event_loop_policy* fixture parametrizes all async tests. The following example causes all async tests to run multiple times, once for each event loop in the fixture parameters:
+
+.. include:: multiple_loops_example.py
+    :code: python
+
+You may choose to limit the scope of the fixture to *package,* *module,* or *class,* if you only want a subset of your tests to run with different event loops.

--- a/docs/source/how-to-guides/multiple_loops_example.py
+++ b/docs/source/how-to-guides/multiple_loops_example.py
@@ -1,0 +1,24 @@
+import asyncio
+from asyncio import DefaultEventLoopPolicy
+
+import pytest
+
+
+class CustomEventLoopPolicy(DefaultEventLoopPolicy):
+    pass
+
+
+@pytest.fixture(
+    scope="session",
+    params=(
+        CustomEventLoopPolicy(),
+        CustomEventLoopPolicy(),
+    ),
+)
+def event_loop_policy(request):
+    return request.param
+
+
+@pytest.mark.asyncio
+async def test_uses_custom_event_loop_policy():
+    assert isinstance(asyncio.get_event_loop_policy(), CustomEventLoopPolicy)

--- a/docs/source/how-to-guides/uvloop.rst
+++ b/docs/source/how-to-guides/uvloop.rst
@@ -2,12 +2,17 @@
 How to test with uvloop
 =======================
 
+Redefinig the *event_loop_policy* fixture will parametrize all async tests. The following example causes all async tests to run multiple times, once for each event loop in the fixture parameters:
 Replace the default event loop policy in your *conftest.py:*
 
 .. code-block:: python
 
-    import asyncio
-
+    import pytest
     import uvloop
 
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+    @pytest.fixture(scope="session")
+    def event_loop_policy():
+        return uvloop.EventLoopPolicy()
+
+You may choose to limit the scope of the fixture to *package,* *module,* or *class,* if you only want a subset of your tests to run with uvloop.

--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 0.23.0 (UNRELEASED)
 ===================
 - Removes pytest-trio from the test dependencies `#620 <https://github.com/pytest-dev/pytest-asyncio/pull/620>`_
+- Introduces the *event_loop_policy* fixture which allows testing with non-default or multiple event loops  `#662 <https://github.com/pytest-dev/pytest-asyncio/pull/662>`_
 
 0.22.0 (2023-10-31)
 ===================

--- a/docs/source/reference/fixtures/event_loop_policy_example.py
+++ b/docs/source/reference/fixtures/event_loop_policy_example.py
@@ -1,0 +1,17 @@
+import asyncio
+
+import pytest
+
+
+class CustomEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+    pass
+
+
+@pytest.fixture(scope="module")
+def event_loop_policy(request):
+    return CustomEventLoopPolicy()
+
+
+@pytest.mark.asyncio(scope="module")
+async def test_uses_custom_event_loop_policy():
+    assert isinstance(asyncio.get_event_loop_policy(), CustomEventLoopPolicy)

--- a/docs/source/reference/fixtures/event_loop_policy_parametrized_example.py
+++ b/docs/source/reference/fixtures/event_loop_policy_parametrized_example.py
@@ -1,0 +1,23 @@
+import asyncio
+from asyncio import DefaultEventLoopPolicy
+
+import pytest
+
+
+class CustomEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+    pass
+
+
+@pytest.fixture(
+    params=(
+        DefaultEventLoopPolicy(),
+        CustomEventLoopPolicy(),
+    ),
+)
+def event_loop_policy(request):
+    return request.param
+
+
+@pytest.mark.asyncio
+async def test_uses_custom_event_loop_policy():
+    assert isinstance(asyncio.get_event_loop_policy(), DefaultEventLoopPolicy)

--- a/docs/source/reference/fixtures/index.rst
+++ b/docs/source/reference/fixtures/index.rst
@@ -22,6 +22,24 @@ If you need to change the type of the event loop, prefer setting a custom event 
 If the ``pytest.mark.asyncio`` decorator is applied to a test function, the ``event_loop``
 fixture will be requested automatically by the test function.
 
+event_loop_policy
+=================
+Returns the event loop policy used to create asyncio event loops.
+The default return value is *asyncio.get_event_loop_policy().*
+
+This fixture can be overridden when a different event loop policy should be used.
+
+.. include:: event_loop_policy_example.py
+    :code: python
+
+Multiple policies can be provided via fixture parameters.
+The fixture is automatically applied to all pytest-asyncio tests.
+Therefore, all tests managed by pytest-asyncio are run once for each fixture parameter.
+The following example runs the test with different event loop policies.
+
+.. include:: event_loop_policy_parametrized_example.py
+    :code: python
+
 unused_tcp_port
 ===============
 Finds and yields a single unused TCP port on the localhost interface. Useful for

--- a/docs/source/reference/markers/class_scoped_loop_custom_policies_strict_mode_example.py
+++ b/docs/source/reference/markers/class_scoped_loop_custom_policies_strict_mode_example.py
@@ -3,12 +3,16 @@ import asyncio
 import pytest
 
 
-@pytest.mark.asyncio_event_loop(
-    policy=[
+@pytest.fixture(
+    params=[
         asyncio.DefaultEventLoopPolicy(),
         asyncio.DefaultEventLoopPolicy(),
     ]
 )
+def event_loop_policy(request):
+    return request.param
+
+
 class TestWithDifferentLoopPolicies:
     @pytest.mark.asyncio
     async def test_parametrized_loop(self):

--- a/docs/source/reference/markers/class_scoped_loop_custom_policy_strict_mode_example.py
+++ b/docs/source/reference/markers/class_scoped_loop_custom_policy_strict_mode_example.py
@@ -7,7 +7,12 @@ class CustomEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
     pass
 
 
-@pytest.mark.asyncio_event_loop(policy=CustomEventLoopPolicy())
+@pytest.fixture(scope="class")
+def event_loop_policy(request):
+    return CustomEventLoopPolicy()
+
+
+@pytest.mark.asyncio_event_loop
 class TestUsesCustomEventLoopPolicy:
     @pytest.mark.asyncio
     async def test_uses_custom_event_loop_policy(self):

--- a/tests/markers/test_class_marker.py
+++ b/tests/markers/test_class_marker.py
@@ -140,8 +140,12 @@ def test_asyncio_event_loop_mark_allows_specifying_the_loop_policy(
             class CustomEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
                 pass
 
-            @pytest.mark.asyncio_event_loop(policy=CustomEventLoopPolicy())
-            class TestUsesCustomEventLoopPolicy:
+            @pytest.mark.asyncio_event_loop
+            class TestUsesCustomEventLoop:
+
+                @pytest.fixture(scope="class")
+                def event_loop_policy(self):
+                    return CustomEventLoopPolicy()
 
                 @pytest.mark.asyncio
                 async def test_uses_custom_event_loop_policy(self):
@@ -173,15 +177,18 @@ def test_asyncio_event_loop_mark_allows_specifying_multiple_loop_policies(
 
             import pytest
 
-            @pytest.mark.asyncio_event_loop(
-                policy=[
+            @pytest.fixture(
+                params=[
                     asyncio.DefaultEventLoopPolicy(),
                     asyncio.DefaultEventLoopPolicy(),
                 ]
             )
+            def event_loop_policy(request):
+                return request.param
+
             class TestWithDifferentLoopPolicies:
                 @pytest.mark.asyncio
-                async def test_parametrized_loop(self):
+                async def test_parametrized_loop(self, request):
                     pass
             """
         )

--- a/tests/markers/test_module_marker.py
+++ b/tests/markers/test_module_marker.py
@@ -157,7 +157,11 @@ def test_asyncio_event_loop_mark_allows_specifying_the_loop_policy(
 
             from .custom_policy import CustomEventLoopPolicy
 
-            pytestmark = pytest.mark.asyncio_event_loop(policy=CustomEventLoopPolicy())
+            pytestmark = pytest.mark.asyncio_event_loop
+
+            @pytest.fixture(scope="module")
+            def event_loop_policy():
+                return CustomEventLoopPolicy()
 
             @pytest.mark.asyncio
             async def test_uses_custom_event_loop_policy():
@@ -178,7 +182,7 @@ def test_asyncio_event_loop_mark_allows_specifying_the_loop_policy(
             async def test_does_not_use_custom_event_loop_policy():
                 assert not isinstance(
                     asyncio.get_event_loop_policy(),
-                   CustomEventLoopPolicy,
+                    CustomEventLoopPolicy,
                 )
             """
         ),
@@ -197,12 +201,17 @@ def test_asyncio_event_loop_mark_allows_specifying_multiple_loop_policies(
 
             import pytest
 
-            pytestmark = pytest.mark.asyncio_event_loop(
-                policy=[
+            pytestmark = pytest.mark.asyncio_event_loop
+
+            @pytest.fixture(
+                scope="module",
+                params=[
                     asyncio.DefaultEventLoopPolicy(),
                     asyncio.DefaultEventLoopPolicy(),
-                ]
+                ],
             )
+            def event_loop_policy(request):
+                return request.param
 
             @pytest.mark.asyncio
             async def test_parametrized_loop():


### PR DESCRIPTION
This PR introduces the new fixture _event_loop_policy._ The fixture returns an instance of an _asyncio.AbstractEventLoopPolicy_. By default, the fixture has _session_ (i.e. it is accessible by all tests) and returns the value of _asyncio.get_event_loop_policy()_.

Users can run pytest-asyncio tests with different types of event loops by redefining the fixture to return a different event loop policy. Parametrizing the fixture causes pytest-asyncio tests to be run once for each specified policy. This allows writing tests against multiple different types of event loops.

Although the concept of event loop policies is likely going to be [deprecated in CPython 3.13,](https://github.com/python/cpython/issues/94597) it was decided that this functionality is still going to land in pytest-asyncio. Starting with CPython 3.13, pytest-asyncio will provide a migration path for the deprecated policy system.

Resolves #591 
Prerequisite for #657 