### PR TITLE
Async fixtures request wrong event loop

### DIFF
--- a/docs/source/reference/markers/class_scoped_loop_with_fixture_strict_mode_example.py
+++ b/docs/source/reference/markers/class_scoped_loop_with_fixture_strict_mode_example.py
@@ -9,7 +9,7 @@ import pytest_asyncio
 class TestClassScopedLoop:
     loop: asyncio.AbstractEventLoop
 
-    @pytest_asyncio.fixture
+    @pytest_asyncio.fixture(scope="class")
     async def my_fixture(self):
         TestClassScopedLoop.loop = asyncio.get_running_loop()
 

--- a/tests/async_fixtures/test_async_fixtures_with_finalizer.py
+++ b/tests/async_fixtures/test_async_fixtures_with_finalizer.py
@@ -4,13 +4,13 @@ import functools
 import pytest
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="module")
 async def test_module_with_event_loop_finalizer(port_with_event_loop_finalizer):
     await asyncio.sleep(0.01)
     assert port_with_event_loop_finalizer
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="module")
 async def test_module_with_get_event_loop_finalizer(port_with_get_event_loop_finalizer):
     await asyncio.sleep(0.01)
     assert port_with_get_event_loop_finalizer

--- a/tests/hypothesis/test_base.py
+++ b/tests/hypothesis/test_base.py
@@ -8,10 +8,22 @@ from hypothesis import given, strategies as st
 from pytest import Pytester
 
 
-@given(st.integers())
-@pytest.mark.asyncio
-async def test_mark_inner(n):
-    assert isinstance(n, int)
+def test_hypothesis_given_decorator_before_asyncio_mark(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+            import pytest
+            from hypothesis import given, strategies as st
+
+            @given(st.integers())
+            @pytest.mark.asyncio
+            async def test_mark_inner(n):
+                assert isinstance(n, int)
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
+    result.assert_outcomes(passed=1)
 
 
 @pytest.mark.asyncio

--- a/tests/hypothesis/test_base.py
+++ b/tests/hypothesis/test_base.py
@@ -54,8 +54,14 @@ def test_can_use_explicit_event_loop_fixture(pytester: Pytester):
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
-    result.assert_outcomes(passed=1)
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
+    result.assert_outcomes(passed=1, warnings=2)
+    result.stdout.fnmatch_lines(
+        [
+            '*is asynchronous and explicitly requests the "event_loop" fixture*',
+            "*event_loop fixture provided by pytest-asyncio has been redefined*",
+        ]
+    )
 
 
 def test_async_auto_marked(pytester: Pytester):

--- a/tests/markers/test_class_scope.py
+++ b/tests/markers/test_class_scope.py
@@ -220,3 +220,34 @@ def test_asyncio_mark_provides_class_scoped_loop_to_fixtures(
     )
     result = pytester.runpytest_subprocess("--asyncio-mode=strict")
     result.assert_outcomes(passed=1)
+
+
+def test_asyncio_mark_allows_combining_class_scoped_fixture_with_function_scoped_test(
+    pytester: pytest.Pytester,
+):
+    pytester.makepyfile(
+        dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            class TestMixedScopes:
+                @pytest_asyncio.fixture(scope="class")
+                async def async_fixture(self):
+                    global loop
+                    loop = asyncio.get_running_loop()
+
+                @pytest.mark.asyncio(scope="function")
+                async def test_runs_in_different_loop_as_fixture(self, async_fixture):
+                    global loop
+                    assert asyncio.get_running_loop() is not loop
+
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)

--- a/tests/markers/test_function_scope.py
+++ b/tests/markers/test_function_scope.py
@@ -43,7 +43,7 @@ def test_function_scope_supports_explicit_event_loop_fixture_request(
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
     result.assert_outcomes(passed=1, warnings=1)
     result.stdout.fnmatch_lines(
         '*is asynchronous and explicitly requests the "event_loop" fixture*'

--- a/tests/markers/test_module_scope.py
+++ b/tests/markers/test_module_scope.py
@@ -219,3 +219,64 @@ def test_asyncio_mark_provides_module_scoped_loop_to_fixtures(
     )
     result = pytester.runpytest_subprocess("--asyncio-mode=strict")
     result.assert_outcomes(passed=1)
+
+
+def test_asyncio_mark_allows_combining_module_scoped_fixture_with_class_scoped_test(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            @pytest_asyncio.fixture(scope="module")
+            async def async_fixture():
+                global loop
+                loop = asyncio.get_running_loop()
+
+            @pytest.mark.asyncio(scope="class")
+            class TestMixedScopes:
+                async def test_runs_in_different_loop_as_fixture(self, async_fixture):
+                    global loop
+                    assert asyncio.get_running_loop() is not loop
+
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)
+
+
+def test_asyncio_mark_allows_combining_module_scoped_fixture_with_function_scoped_test(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        __init__="",
+        test_mixed_scopes=dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            @pytest_asyncio.fixture(scope="module")
+            async def async_fixture():
+                global loop
+                loop = asyncio.get_running_loop()
+
+            @pytest.mark.asyncio(scope="function")
+            async def test_runs_in_different_loop_as_fixture(async_fixture):
+                global loop
+                assert asyncio.get_running_loop() is not loop
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)

--- a/tests/markers/test_module_scope.py
+++ b/tests/markers/test_module_scope.py
@@ -48,8 +48,11 @@ def test_asyncio_mark_works_on_module_level(pytester: Pytester):
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
-    result.assert_outcomes(passed=2)
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
+    result.assert_outcomes(passed=2, warnings=2)
+    result.stdout.fnmatch_lines(
+        '*is asynchronous and explicitly requests the "event_loop" fixture*'
+    )
 
 
 def test_asyncio_mark_provides_module_scoped_loop_strict_mode(pytester: Pytester):

--- a/tests/markers/test_package_scope.py
+++ b/tests/markers/test_package_scope.py
@@ -223,3 +223,94 @@ def test_asyncio_mark_provides_package_scoped_loop_to_fixtures(
     )
     result = pytester.runpytest_subprocess("--asyncio-mode=strict")
     result.assert_outcomes(passed=1)
+
+
+def test_asyncio_mark_allows_combining_package_scoped_fixture_with_module_scoped_test(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        __init__="",
+        test_mixed_scopes=dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            @pytest_asyncio.fixture(scope="package")
+            async def async_fixture():
+                global loop
+                loop = asyncio.get_running_loop()
+
+            @pytest.mark.asyncio(scope="module")
+            async def test_runs_in_different_loop_as_fixture(async_fixture):
+                global loop
+                assert asyncio.get_running_loop() is not loop
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)
+
+
+def test_asyncio_mark_allows_combining_package_scoped_fixture_with_class_scoped_test(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        __init__="",
+        test_mixed_scopes=dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            @pytest_asyncio.fixture(scope="package")
+            async def async_fixture():
+                global loop
+                loop = asyncio.get_running_loop()
+
+            @pytest.mark.asyncio(scope="class")
+            class TestMixedScopes:
+                async def test_runs_in_different_loop_as_fixture(self, async_fixture):
+                    global loop
+                    assert asyncio.get_running_loop() is not loop
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)
+
+
+def test_asyncio_mark_allows_combining_package_scoped_fixture_with_function_scoped_test(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        __init__="",
+        test_mixed_scopes=dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            @pytest_asyncio.fixture(scope="package")
+            async def async_fixture():
+                global loop
+                loop = asyncio.get_running_loop()
+
+            @pytest.mark.asyncio
+            async def test_runs_in_different_loop_as_fixture(async_fixture):
+                global loop
+                assert asyncio.get_running_loop() is not loop
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)

--- a/tests/markers/test_session_scope.py
+++ b/tests/markers/test_session_scope.py
@@ -227,3 +227,124 @@ def test_asyncio_mark_provides_session_scoped_loop_to_fixtures(
     )
     result = pytester.runpytest_subprocess("--asyncio-mode=strict")
     result.assert_outcomes(passed=1)
+
+
+def test_asyncio_mark_allows_combining_session_scoped_fixture_with_package_scoped_test(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        __init__="",
+        test_mixed_scopes=dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            @pytest_asyncio.fixture(scope="session")
+            async def async_fixture():
+                global loop
+                loop = asyncio.get_running_loop()
+
+            @pytest.mark.asyncio(scope="package")
+            async def test_runs_in_different_loop_as_fixture(async_fixture):
+                global loop
+                assert asyncio.get_running_loop() is not loop
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)
+
+
+def test_asyncio_mark_allows_combining_session_scoped_fixture_with_module_scoped_test(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        __init__="",
+        test_mixed_scopes=dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            @pytest_asyncio.fixture(scope="session")
+            async def async_fixture():
+                global loop
+                loop = asyncio.get_running_loop()
+
+            @pytest.mark.asyncio(scope="module")
+            async def test_runs_in_different_loop_as_fixture(async_fixture):
+                global loop
+                assert asyncio.get_running_loop() is not loop
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)
+
+
+def test_asyncio_mark_allows_combining_session_scoped_fixture_with_class_scoped_test(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        __init__="",
+        test_mixed_scopes=dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            @pytest_asyncio.fixture(scope="session")
+            async def async_fixture():
+                global loop
+                loop = asyncio.get_running_loop()
+
+            @pytest.mark.asyncio(scope="class")
+            class TestMixedScopes:
+                async def test_runs_in_different_loop_as_fixture(self, async_fixture):
+                    global loop
+                    assert asyncio.get_running_loop() is not loop
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)
+
+
+def test_asyncio_mark_allows_combining_session_scoped_fixture_with_function_scoped_test(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        __init__="",
+        test_mixed_scopes=dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            @pytest_asyncio.fixture(scope="session")
+            async def async_fixture():
+                global loop
+                loop = asyncio.get_running_loop()
+
+            @pytest.mark.asyncio
+            async def test_runs_in_different_loop_as_fixture(async_fixture):
+                global loop
+                assert asyncio.get_running_loop() is not loop
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)

--- a/tests/test_event_loop_fixture_finalizer.py
+++ b/tests/test_event_loop_fixture_finalizer.py
@@ -84,8 +84,11 @@ def test_event_loop_fixture_finalizer_handles_loop_set_to_none_async_with_fixtur
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
-    result.assert_outcomes(passed=1)
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
+    result.assert_outcomes(passed=1, warnings=1)
+    result.stdout.fnmatch_lines(
+        '*is asynchronous and explicitly requests the "event_loop" fixture*'
+    )
 
 
 def test_event_loop_fixture_finalizer_raises_warning_when_fixture_leaves_loop_unclosed(

--- a/tests/test_event_loop_fixture_override_deprecation.py
+++ b/tests/test_event_loop_fixture_override_deprecation.py
@@ -22,7 +22,7 @@ def test_emit_warning_when_event_loop_fixture_is_redefined(pytester: Pytester):
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
     result.assert_outcomes(passed=1, warnings=1)
     result.stdout.fnmatch_lines(
         ["*event_loop fixture provided by pytest-asyncio has been redefined*"]
@@ -50,7 +50,7 @@ def test_emit_warning_when_event_loop_fixture_is_redefined_explicit_request(
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
     result.assert_outcomes(passed=1, warnings=2)
     result.stdout.fnmatch_lines(
         ["*event_loop fixture provided by pytest-asyncio has been redefined*"]
@@ -107,5 +107,5 @@ def test_emit_warning_when_redefined_event_loop_is_used_by_fixture(pytester: Pyt
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
     result.assert_outcomes(passed=1, warnings=1)

--- a/tests/test_explicit_event_loop_fixture_request.py
+++ b/tests/test_explicit_event_loop_fixture_request.py
@@ -17,7 +17,7 @@ def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine(
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
     result.assert_outcomes(passed=1, warnings=1)
     result.stdout.fnmatch_lines(
         ['*is asynchronous and explicitly requests the "event_loop" fixture*']
@@ -39,7 +39,7 @@ def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine_metho
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
     result.assert_outcomes(passed=1, warnings=1)
     result.stdout.fnmatch_lines(
         ['*is asynchronous and explicitly requests the "event_loop" fixture*']
@@ -62,7 +62,7 @@ def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine_stati
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
     result.assert_outcomes(passed=1, warnings=1)
     result.stdout.fnmatch_lines(
         ['*is asynchronous and explicitly requests the "event_loop" fixture*']
@@ -88,7 +88,7 @@ def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine_fixtu
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
     result.assert_outcomes(passed=1, warnings=1)
     result.stdout.fnmatch_lines(
         ['*is asynchronous and explicitly requests the "event_loop" fixture*']
@@ -114,7 +114,7 @@ def test_emit_warning_when_event_loop_is_explicitly_requested_in_async_gen_fixtu
             """
         )
     )
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
     result.assert_outcomes(passed=1, warnings=1)
     result.stdout.fnmatch_lines(
         ['*is asynchronous and explicitly requests the "event_loop" fixture*']


### PR DESCRIPTION
Fixes a bug that caused tests to run in the wrong event loop when requesting larger-scoped fixtures in a narrower-scoped test.

Previously, pytest-asyncio relied on marks applied to pytest Collectors (e.g. classes and modules) to determine the loop scope. This logic is no longer applicable for fixtures, because pytest-asyncio now relies on the asyncio mark applied to tests. As a result, fixtures were looking for an "asyncio" mark on surrounding collectors to no avail and defaulted to choosing a function-scoped loop.

This patch chooses the loop scope based on the fixture scope.

Resolves #658 
Resolves #670 