### PR TITLE
Address internal pytest error during collection of doctests

### DIFF
--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -1,0 +1,19 @@
+from textwrap import dedent
+
+from pytest import Pytester
+
+
+def test_plugin_does_not_interfere_with_doctest_collection(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            '''\
+            def any_function():
+                """
+                >>> 42
+                42
+                """
+            '''
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict", "--doctest-modules")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
This PR fixes a bug that caused internal pytest errors during test collection with doctests.

Pytest-asyncio attaches an event loop of a particular scope to each collector during pytest_collectstart. The implementation did not account for the fact that collectors may have specialized subclasses, such as DoctestModule. This caused a KeyError during a dictionary access, leading to an internal pytest error in the collection phase.

This patch changes the implementation of pytest_collectstart to account for subclasses of collectors.

Resolves #679 