### PR TITLE
Fix collection error for .txt files

### DIFF
--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+0.23.2 (2023-12-04)
+===================
+- Fixes a bug that caused an internal pytest error when collecting .txt files `#703 <https://github.com/pytest-dev/pytest-asyncio/issues/703>`_
+
+
 0.23.1 (2023-12-03)
 ===================
 - Fixes a bug that caused an internal pytest error when using module-level skips `#701 <https://github.com/pytest-dev/pytest-asyncio/issues/701>`_

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -609,7 +609,11 @@ def pytest_collectstart(collector: pytest.Collector):
     # collected Python class, where it will be picked up by pytest.Class.collect()
     # or pytest.Module.collect(), respectively
     try:
-        collector.obj.__pytest_asyncio_scoped_event_loop = scoped_event_loop
+        pyobject = collector.obj
+        # If the collected module is a DoctestTextfile, collector.obj is None
+        if pyobject is None:
+            return
+        pyobject.__pytest_asyncio_scoped_event_loop = scoped_event_loop
     except (OutcomeException, Collector.CollectError):
         # Accessing Module.obj triggers a module import executing module-level
         # statements. A module-level pytest.skip statement raises the "Skipped"

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -17,3 +17,23 @@ def test_plugin_does_not_interfere_with_doctest_collection(pytester: Pytester):
     )
     result = pytester.runpytest("--asyncio-mode=strict", "--doctest-modules")
     result.assert_outcomes(passed=1)
+
+
+def test_plugin_does_not_interfere_with_doctest_textfile_collection(pytester: Pytester):
+    pytester.makefile(".txt", "")  # collected as DoctestTextfile
+    pytester.makepyfile(
+        __init__="",
+        test_python_file=dedent(
+            """\
+                import pytest
+
+                pytest_plugins = "pytest_asyncio"
+
+                @pytest.mark.asyncio
+                async def test_anything():
+                    pass
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Fixes a bug that caused an internal pytest error when collecting .txt files.

When pytest encounters a .txt file, it is collected as a DoctestTextFile. Although DoctestTextFile is considered a subtype of Module, its obj property is always None and causes an INTERNALERROR.

https://github.com/pytest-dev/pytest/blob/714ce2e872f0e1dc3b0363949d084e3e64f88c82/src/_pytest/doctest.py#L422-L423

Resolves #703 