### PR TITLE
[fix] Change `packages_dir` to `packages-dir`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
     - name: PyPI upload
       uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
-        packages_dir: dist
+        packages-dir: dist
         password: ${{ secrets.PYPI_API_TOKEN }}
     - name: GitHub Release
       uses: ncipollo/release-action@v1


### PR DESCRIPTION
This should fix #699 and prevent the warning.

Closes #699 