### PR TITLE
Prevent premature closing of scoped event loops

### DIFF
--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+0.23.3 (UNRELEASED)
+===================
+- Fixes a bug that caused event loops to be closed prematurely when using async generator fixtures with class scope or wider in a function-scoped test `#708 <https://github.com/pytest-dev/pytest-asyncio/issues/708>`_
+
+
 0.23.2 (2023-12-04)
 ===================
 - Fixes a bug that caused an internal pytest error when collecting .txt files `#703 <https://github.com/pytest-dev/pytest-asyncio/issues/703>`_

--- a/tests/markers/test_module_scope.py
+++ b/tests/markers/test_module_scope.py
@@ -282,6 +282,36 @@ def test_asyncio_mark_allows_combining_module_scoped_fixture_with_function_scope
     result.assert_outcomes(passed=1)
 
 
+def test_allows_combining_module_scoped_asyncgen_fixture_with_function_scoped_test(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            @pytest_asyncio.fixture(scope="module")
+            async def async_fixture():
+                global loop
+                loop = asyncio.get_running_loop()
+                yield
+
+            @pytest.mark.asyncio(scope="function")
+            async def test_runs_in_different_loop_as_fixture(async_fixture):
+                global loop
+                assert asyncio.get_running_loop() is not loop
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)
+
+
 def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     pytester: Pytester,
 ):

--- a/tests/markers/test_session_scope.py
+++ b/tests/markers/test_session_scope.py
@@ -350,6 +350,37 @@ def test_asyncio_mark_allows_combining_session_scoped_fixture_with_function_scop
     result.assert_outcomes(passed=1)
 
 
+def test_allows_combining_session_scoped_asyncgen_fixture_with_function_scoped_test(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        __init__="",
+        test_mixed_scopes=dedent(
+            """\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            loop: asyncio.AbstractEventLoop
+
+            @pytest_asyncio.fixture(scope="session")
+            async def async_fixture():
+                global loop
+                loop = asyncio.get_running_loop()
+                yield
+
+            @pytest.mark.asyncio
+            async def test_runs_in_different_loop_as_fixture(async_fixture):
+                global loop
+                assert asyncio.get_running_loop() is not loop
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)
+
+
 def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     pytester: Pytester,
 ):


### PR DESCRIPTION
Fixes a bug that caused event loops to be closed prematurely when using async generator fixtures with class scope or wider in a function-scoped test.

The fixture setup of the "event_loop" fixture closes any existing loop. The existing loop could also belong to a pytest-asyncio scoped event loop fixture. This caused async generator fixtures using the scoped loop to raise a RuntimeError on teardown, because the scoped loop was closed before the fixture finalizer could not be run. In fact, everything after the async generation fixture's "yield" statement had no functioning event loop.

The issue was addressed by adding a special attribute to the scoped event loops provided by pytest-asyncio. If this attribute is present, the setup code of the "event_loop" fixture will not close the loop. This allows keeping backwards compatibility for code that doesn't use scoped loops. It is assumed that the magic attribute can be removed after the deprecation period of event_loop_ fixture overrides.

Fixes #708 