### PR TITLE
Address internal pytest errors during collection

### DIFF
--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 0.23.3 (UNRELEASED)
 ===================
-- Fixes a bug that caused event loops to be closed prematurely when using async generator fixtures with class scope or wider in a function-scoped test `#708 <https://github.com/pytest-dev/pytest-asyncio/issues/708>`_
+- Fixes a bug that caused event loops to be closed prematurely when using async generator fixtures with class scope or wider in a function-scoped test `#706 <https://github.com/pytest-dev/pytest-asyncio/issues/706>`_
 - Fixes a bug that caused an internal pytest error when using unittest.SkipTest in a module `#711 <https://github.com/pytest-dev/pytest-asyncio/issues/711>`_
 - Fixes a bug that caused an internal pytest error when an ImportWarning is emitted in a module `#713 <https://github.com/pytest-dev/pytest-asyncio/issues/713>`_
 

--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -5,8 +5,8 @@ Changelog
 0.23.3 (UNRELEASED)
 ===================
 - Fixes a bug that caused event loops to be closed prematurely when using async generator fixtures with class scope or wider in a function-scoped test `#706 <https://github.com/pytest-dev/pytest-asyncio/issues/706>`_
-- Fixes a bug that caused an internal pytest error when using unittest.SkipTest in a module `#711 <https://github.com/pytest-dev/pytest-asyncio/issues/711>`_
-- Fixes a bug that caused an internal pytest error when an ImportWarning is emitted in a module `#713 <https://github.com/pytest-dev/pytest-asyncio/issues/713>`_
+- Fixes various bugs that caused an internal pytest error during test collection `#711 <https://github.com/pytest-dev/pytest-asyncio/issues/711>`_ `#713 <https://github.com/pytest-dev/pytest-asyncio/issues/713>`_ `#719 <https://github.com/pytest-dev/pytest-asyncio/issues/719>`_
+
 
 
 0.23.2 (2023-12-04)

--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 ===================
 - Fixes a bug that caused event loops to be closed prematurely when using async generator fixtures with class scope or wider in a function-scoped test `#708 <https://github.com/pytest-dev/pytest-asyncio/issues/708>`_
 - Fixes a bug that caused an internal pytest error when using unittest.SkipTest in a module `#711 <https://github.com/pytest-dev/pytest-asyncio/issues/711>`_
+- Fixes a bug that caused an internal pytest error when an ImportWarning is emitted in a module `#713 <https://github.com/pytest-dev/pytest-asyncio/issues/713>`_
 
 
 0.23.2 (2023-12-04)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,18 @@
+from textwrap import dedent
+
+from pytest import Pytester
+
+
+def test_import_warning(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+                raise ImportWarning()
+
+                async def test_errors_out():
+                    pass
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=auto")
+    result.assert_outcomes(errors=1)


### PR DESCRIPTION
There have been numerous bug reports related to a pytest INTERNALERROR triggered during test collection.The root cause is the installation of the scoped event loop fixture which triggers module imports during `pytest_collectstart`. This specific hook runs before the actual collection phase and is not equipped to deal with this kind of import errors.

This PR monkey patches each Module.collect call and prepends a statement that installs the scoped event loop as part of the _collect_ call. This delays module imports until the collection phase where pytest deals with them properly.

Closes #713 
Closes #719