### PR TITLE
Prevent import of unrealted packages during test collection

### DIFF
--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+0.23.4 (UNRELEASED)
+===================
+- pytest-asyncio no longer imports additional, unrelated packages during test collection `#729 <https://github.com/pytest-dev/pytest-asyncio/issues/729>`_
+
+Known issues
+------------
+As of v0.23, pytest-asyncio attaches an asyncio event loop to each item of the test suite (i.e. session, packages, modules, classes, functions) and allows tests to be run in those loops when marked accordingly. Pytest-asyncio currently assumes that async fixture scope is correlated with the new event loop scope. This prevents fixtures from being evaluated independently from the event loop scope and breaks some existing test suites (see `#706`_). For example, a test suite may require all fixtures and tests to run in the same event loop, but have async fixtures that are set up and torn down for each module. If you're affected by this issue, please continue using the v0.21 release, until it is resolved.
+
 0.23.3 (2024-01-01)
 ===================
 - Fixes a bug that caused event loops to be closed prematurely when using async generator fixtures with class scope or wider in a function-scoped test `#706 <https://github.com/pytest-dev/pytest-asyncio/issues/706>`_

--- a/tests/markers/test_package_scope.py
+++ b/tests/markers/test_package_scope.py
@@ -46,6 +46,7 @@ def test_asyncio_mark_provides_package_scoped_loop_strict_mode(pytester: Pyteste
         ),
     )
     subpkg = pytester.mkpydir(subpackage_name)
+    subpkg.joinpath("__init__.py").touch()
     subpkg.joinpath("test_subpkg.py").write_text(
         dedent(
             f"""\

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 from pytest import Pytester
 
 
-def test_import_warning(pytester: Pytester):
+def test_import_warning_does_not_cause_internal_error(pytester: Pytester):
     pytester.makepyfile(
         dedent(
             """\
@@ -13,6 +13,24 @@ def test_import_warning(pytester: Pytester):
                     pass
             """
         )
+    )
+    result = pytester.runpytest("--asyncio-mode=auto")
+    result.assert_outcomes(errors=1)
+
+
+def test_import_warning_in_package_does_not_cause_internal_error(pytester: Pytester):
+    pytester.makepyfile(
+        __init__=dedent(
+            """\
+                raise ImportWarning()
+            """
+        ),
+        test_a=dedent(
+            """\
+                async def test_errors_out():
+                    pass
+            """
+        ),
     )
     result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(errors=1)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -34,3 +34,25 @@ def test_import_warning_in_package_does_not_cause_internal_error(pytester: Pytes
     )
     result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(errors=1)
+
+
+def test_does_not_import_unrelated_packages(pytester: Pytester):
+    pkg_dir = pytester.mkpydir("mypkg")
+    pkg_dir.joinpath("__init__.py").write_text(
+        dedent(
+            """\
+                raise ImportError()
+            """
+        ),
+    )
+    test_dir = pytester.mkdir("tests")
+    test_dir.joinpath("test_a.py").write_text(
+        dedent(
+            """\
+                async def test_passes():
+                    pass
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=auto")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
#729 describes an issue where pytest-asyncio imports packages (i.e. `__init__.py` modules) which are not imported without pytest-asyncio. The imported packages could be test packages and non-test packages. This leads to two issues:
1. The import happens in the `pytest_collectstart` hook just before the collection phase. Pytest isn't equipped to deal with import errors or test skips in this hook, so the import can trigger an INTERNALERROR which aborts the test run completely.
2. Importing packages that are unrelated to the test run may trigger ImportErrors or ImportWarnings. The greedy import behaviour can even cause issues just by changing the import order (refer to  due to a change in the import order (refer to [this comment](https://github.com/pytest-dev/pytest-asyncio/issues/729#issuecomment-1872990077) about the `torch` package)

This PR "tackles" the problem by monkey patching the Package.collect method, which delays any collection errors to the actual collection phase and addresses problem 1.

The patch also adds a call to `collector.funcnamefilter`, in order to skip packages that don't contain test code. The fixture function for a package-scoped loop is installed into a temporary Python module in the current package rather than into the `__init__.py` to avoid further problems. This solves problem 2.

This code is expected to be a temporary bandaid. The collection logic has changed in pytest 8, so that each Package only collects its current directory rather than all subdirectories. This will allow pytest-asyncio to get rid of the code that tracks sub-package paths and assembles fixture IDs based on them.

Moreover, there are efforts by the pytest developers to allow fixtures to be attached to a certain node, which would eliminate the monkey patching.