### PR TITLE
[build] Constrain the maximum supported pytest version to pytest <8.

### DIFF
--- a/dependencies/default/requirements.txt
+++ b/dependencies/default/requirements.txt
@@ -1,3 +1,3 @@
 # Always adjust install_requires in setup.cfg and pytest-min-requirements.txt
 # when changing runtime dependencies
-pytest >= 7.0.0
+pytest >= 7.0.0,<8

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ include_package_data = True
 
 # Always adjust requirements.txt and pytest-min-requirements.txt when changing runtime dependencies
 install_requires =
-  pytest >= 7.0.0
+  pytest >= 7.0.0,<8
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
Pytest 8 made some changes to its test collection and pytest-asyncio currently isn't compatible with those changes.
see https://github.com/pytest-dev/pytest-asyncio/issues/737