### PR TITLE
Fixes a bug that breaks virtual modules on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,11 +56,12 @@ jobs:
         path: dist
 
   test:
-    name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
@@ -75,7 +76,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        set -xe
         python -VV
         python -m site
         python -m pip install --upgrade pip
@@ -85,6 +85,7 @@ jobs:
 
     - name: Store coverage data
       uses: actions/upload-artifact@v3
+      if: "!endsWith(matrix.os, 'windows')"
       with:
         name: coverage-per-interpreter
         path: .coverage.*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,11 +57,11 @@ jobs:
 
   test:
     name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu, windows]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -8,7 +8,7 @@ if sys.platform == "win32":
     # The default asyncio event loop implementation on Windows does not
     # support subprocesses. Subprocesses are available for Windows if a
     # ProactorEventLoop is used.
-    @pytest.yield_fixture()
+    @pytest.fixture()
     def event_loop():
         loop = asyncio.ProactorEventLoop()
         yield loop


### PR DESCRIPTION
pytest-asyncio v0.23.4a0 introduced "virtual modules". These are temporary files in Python packages which contain a fixture definition. The files are removed after the virtual module was collected by pytest.

The use of temporary files has platform-specific behavior. Apparently, pytest opens the NamedTemporaryFile again, which causes issues on Windows. The [the docs](https://docs.python.org/3.12/library/tempfile.html#tempfile.NamedTemporaryFile) describe the problem and possible mitigations:

> Opening the temporary file again by its name while it is still open works as follows:
>     On POSIX the file can always be opened again.
>     On Windows, make sure that at least one of the following conditions are fulfilled:
>         * delete is false
>         * additional open shares delete access (e.g. by calling [os.open()](https://docs.python.org/3.12/library/os.html#os.open) with the flag O_TEMPORARY)
>         * delete is true but delete_on_close is false. Note, that in this case the additional opens that do not share delete access (e.g. created via builtin [open()](https://docs.python.org/3.12/library/functions.html#open)) must be closed before exiting the context manager, else the [os.unlink()](https://docs.python.org/3.12/library/os.html#os.unlink) call on context manager exit will fail with a [PermissionError](https://docs.python.org/3.12/library/exceptions.html#PermissionError).
> 

The `delete_on_close` flag has only been added in Python 3.12, so pytest-asyncio cannot use it at the moment. Neither does pytest-asyncio have the means to influence how pytest opens a file for collection. This leaves us with setting `delete=False` in the constructor of the _NamedTemporaryFile_ and clean it up manually.

This PR also enabled CI tests on Windows to reproduce the problem (and validate the fix).

See #729 