### PR TITLE
Prevent collection issues with skip statements inside packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   hooks:
   - id: yesqa
 - repo: https://github.com/Zac-HD/shed
-  rev: 0.10.7
+  rev: 2024.1.1
   hooks:
   - id: shed
     args:

--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-0.23.4 (UNRELEASED)
+0.23.4 (2024-01-28)
 ===================
 - pytest-asyncio no longer imports additional, unrelated packages during test collection `#729 <https://github.com/pytest-dev/pytest-asyncio/issues/729>`_
 - Addresses further issues that caused an internal pytest error during test collection

--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 ===================
 - pytest-asyncio no longer imports additional, unrelated packages during test collection `#729 <https://github.com/pytest-dev/pytest-asyncio/issues/729>`_
 - Addresses further issues that caused an internal pytest error during test collection
+- Declares incompatibility with pytest 8 `#737 <https://github.com/pytest-dev/pytest-asyncio/issues/737>`_
 
 Known issues
 ------------

--- a/pytest_asyncio/__init__.py
+++ b/pytest_asyncio/__init__.py
@@ -1,4 +1,5 @@
 """The main point for importing pytest-asyncio items."""
+
 from ._version import version as __version__  # noqa
 from .plugin import fixture, is_async_test
 

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -1,4 +1,5 @@
 """pytest-asyncio implementation."""
+
 import asyncio
 import contextlib
 import enum
@@ -115,8 +116,7 @@ def fixture(
         None,
     ] = ...,
     name: Optional[str] = ...,
-) -> FixtureFunction:
-    ...
+) -> FixtureFunction: ...
 
 
 @overload
@@ -132,8 +132,7 @@ def fixture(
         None,
     ] = ...,
     name: Optional[str] = None,
-) -> FixtureFunctionMarker:
-    ...
+) -> FixtureFunctionMarker: ...
 
 
 def fixture(
@@ -720,9 +719,9 @@ def pytest_generate_tests(metafunc: Metafunc) -> None:
         # The fixture needs to be appended to avoid messing up the fixture evaluation
         # order
         metafunc.fixturenames.append(event_loop_fixture_id)
-        metafunc._arg2fixturedefs[
-            event_loop_fixture_id
-        ] = fixturemanager._arg2fixturedefs[event_loop_fixture_id]
+        metafunc._arg2fixturedefs[event_loop_fixture_id] = (
+            fixturemanager._arg2fixturedefs[event_loop_fixture_id]
+        )
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/async_fixtures/test_async_fixtures_scope.py
+++ b/tests/async_fixtures/test_async_fixtures_scope.py
@@ -2,6 +2,7 @@
 We support module-scoped async fixtures, but only if the event loop is
 module-scoped too.
 """
+
 import asyncio
 
 import pytest

--- a/tests/hypothesis/test_base.py
+++ b/tests/hypothesis/test_base.py
@@ -1,6 +1,7 @@
 """Tests for the Hypothesis integration, which wraps async functions in a
 sync shim for Hypothesis.
 """
+
 from textwrap import dedent
 
 import pytest

--- a/tests/loop_fixture_scope/test_loop_fixture_scope.py
+++ b/tests/loop_fixture_scope/test_loop_fixture_scope.py
@@ -1,4 +1,5 @@
 """Unit tests for overriding the event loop with a larger scoped one."""
+
 import asyncio
 
 import pytest

--- a/tests/markers/test_class_scope.py
+++ b/tests/markers/test_class_scope.py
@@ -1,4 +1,5 @@
 """Test if pytestmark works when defined on a class."""
+
 import asyncio
 from textwrap import dedent
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,4 +1,5 @@
 """Quick'n'dirty unit tests for provided fixtures and markers."""
+
 import asyncio
 from textwrap import dedent
 

--- a/tests/test_skips.py
+++ b/tests/test_skips.py
@@ -105,3 +105,33 @@ def test_unittest_skiptest_compatibility(pytester: Pytester):
     )
     result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(skipped=1)
+
+
+def test_skip_in_module_does_not_skip_package(pytester: Pytester):
+    pytester.makepyfile(
+        __init__="",
+        test_skip=dedent(
+            """\
+                import pytest
+
+                pytest.skip("Skip all tests", allow_module_level=True)
+
+                def test_a():
+                    pass
+
+                def test_b():
+                    pass
+            """
+        ),
+        test_something=dedent(
+            """\
+                import pytest
+
+                @pytest.mark.asyncio
+                async def test_something():
+                    pass
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1, skipped=1)

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -1,4 +1,5 @@
 """Tests for using subprocesses in tests."""
+
 import asyncio.subprocess
 import sys
 


### PR DESCRIPTION
pytest-asyncio-0.23.4a2 suffers from a problem that causes tests to be skipped during the collection phase as described in 
https://github.com/pytest-dev/pytest-asyncio/issues/729#issuecomment-1900518338

It turns out the tests were skipped, because the test suite in question used test packages and the first module inside the package issued a `pytest.skip` statement. The custom collection function for packages introduced in pytest-asyncio-0.23.4a2 tries to access `Module.obj` which triggers the `pytest.skip` and causes the collection of the package to abort.

Rather than trying to access `Module.obj`, this patch adds a package-scoped fixture to a stack each time a package is collected. The first module inside each package tries to pop an item from the stack and adds the popped loop fixture to itself.