### PR TITLE
Prevent DeprecationWarning from reaching user code

### DIFF
--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -2,10 +2,11 @@
 Changelog
 =========
 
-0.23.5 (UNRELEASED)
+0.23.5 (2024-02-09)
 ===================
 - Declare compatibility with pytest 8 `#737 <https://github.com/pytest-dev/pytest-asyncio/issues/737>`_
 - Fix typing errors with recent versions of mypy `#769 <https://github.com/pytest-dev/pytest-asyncio/issues/769>`_
+- Prevent DeprecationWarning about internal use of `asyncio.get_event_loop()` from affecting test cases `#757 <https://github.com/pytest-dev/pytest-asyncio/issues/757>`_
 
 Known issues
 ------------

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -667,7 +667,9 @@ def _removesuffix(s: str, suffix: str) -> str:
 def _temporary_event_loop_policy(policy: AbstractEventLoopPolicy) -> Iterator[None]:
     old_loop_policy = asyncio.get_event_loop_policy()
     try:
-        old_loop = asyncio.get_event_loop()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            old_loop = asyncio.get_event_loop()
     except RuntimeError:
         old_loop = None
     asyncio.set_event_loop_policy(policy)

--- a/tests/markers/test_class_scope.py
+++ b/tests/markers/test_class_scope.py
@@ -287,3 +287,22 @@ def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     )
     result = pytester.runpytest("--asyncio-mode=strict")
     result.assert_outcomes(passed=2)
+
+
+def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_being_set(
+    pytester: pytest.Pytester,
+):
+    pytester.makepyfile(
+        dedent(
+            """\
+            import pytest
+
+            @pytest.mark.asyncio(scope="class")
+            class TestClass:
+                async def test_anything(self):
+                    pass
+            """
+        )
+    )
+    result = pytester.runpytest_subprocess("--asyncio-mode=strict")
+    result.assert_outcomes(warnings=0, passed=1)

--- a/tests/markers/test_function_scope.py
+++ b/tests/markers/test_function_scope.py
@@ -179,3 +179,21 @@ def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     )
     result = pytester.runpytest("--asyncio-mode=strict")
     result.assert_outcomes(passed=2)
+
+
+def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_being_set(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        dedent(
+            """\
+            import pytest
+
+            @pytest.mark.asyncio
+            async def test_anything():
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_subprocess("--asyncio-mode=strict")
+    result.assert_outcomes(warnings=0, passed=1)

--- a/tests/markers/test_module_scope.py
+++ b/tests/markers/test_module_scope.py
@@ -344,3 +344,21 @@ def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     )
     result = pytester.runpytest("--asyncio-mode=strict")
     result.assert_outcomes(passed=2)
+
+
+def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_being_set(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        dedent(
+            """\
+            import pytest
+
+            @pytest.mark.asyncio(scope="module")
+            async def test_anything():
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_subprocess("--asyncio-mode=strict")
+    result.assert_outcomes(warnings=0, passed=1)

--- a/tests/markers/test_package_scope.py
+++ b/tests/markers/test_package_scope.py
@@ -350,3 +350,22 @@ def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     )
     result = pytester.runpytest("--asyncio-mode=strict")
     result.assert_outcomes(passed=2)
+
+
+def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_being_set(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        __init__="",
+        test_module=dedent(
+            """\
+            import pytest
+
+            @pytest.mark.asyncio(scope="package")
+            async def test_anything():
+                pass
+            """
+        ),
+    )
+    result = pytester.runpytest_subprocess("--asyncio-mode=strict")
+    result.assert_outcomes(warnings=0, passed=1)

--- a/tests/markers/test_session_scope.py
+++ b/tests/markers/test_session_scope.py
@@ -415,3 +415,21 @@ def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     )
     result = pytester.runpytest("--asyncio-mode=strict")
     result.assert_outcomes(passed=2)
+
+
+def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_being_set(
+    pytester: Pytester,
+):
+    pytester.makepyfile(
+        dedent(
+            """\
+            import pytest
+
+            @pytest.mark.asyncio(scope="session")
+            async def test_anything():
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest_subprocess("--asyncio-mode=strict")
+    result.assert_outcomes(warnings=0, passed=1)


### PR DESCRIPTION
Pytest-asyncio still uses *asyncio.get_event_loop()*. There are plans to move away from it, but *get_event_loop* is required to maintain compatibility between scoped event loops and loop fixture overrides.

This may lead to instances where the first asyncio test in a test suite emits a *DeprecationWarning*, which bubbles up to the user's test suite.

This PR silences the warning until pytest-asyncio no longer needs to manipulate the event loop directly.

closes  #757