### PR TITLE
Fix compatibility with pytest 8.2 FixtureDef.unittest removal

### DIFF
--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+0.23.6 (2024-03-19)
+===================
+- Fix compatibility with pytest 8.2 `#800 <https://github.com/pytest-dev/pytest-asyncio/pull/800>`_
+
+Known issues
+------------
+As of v0.23, pytest-asyncio attaches an asyncio event loop to each item of the test suite (i.e. session, packages, modules, classes, functions) and allows tests to be run in those loops when marked accordingly. Pytest-asyncio currently assumes that async fixture scope is correlated with the new event loop scope. This prevents fixtures from being evaluated independently from the event loop scope and breaks some existing test suites (see `#706`_). For example, a test suite may require all fixtures and tests to run in the same event loop, but have async fixtures that are set up and torn down for each module. If you're affected by this issue, please continue using the v0.21 release, until it is resolved.
+
+
 0.23.5 (2024-02-09)
 ===================
 - Declare compatibility with pytest 8 `#737 <https://github.com/pytest-dev/pytest-asyncio/issues/737>`_

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -6,7 +6,6 @@ import enum
 import functools
 import inspect
 import socket
-import sys
 import warnings
 from asyncio import AbstractEventLoopPolicy
 from textwrap import dedent
@@ -654,12 +653,6 @@ def pytest_collectstart(collector: pytest.Collector) -> None:
         collector.collect = _patched_collect  # type: ignore[method-assign]
     elif isinstance(collector, Class):
         collector.obj.__pytest_asyncio_scoped_event_loop = scoped_event_loop
-
-
-def _removesuffix(s: str, suffix: str) -> str:
-    if sys.version_info < (3, 9):
-        return s[: -len(suffix)]
-    return s.removesuffix(suffix)
 
 
 @contextlib.contextmanager

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -64,7 +64,6 @@ FixtureFunctionMarker = Callable[[FixtureFunction], FixtureFunction]
 
 # https://github.com/pytest-dev/pytest/pull/9510
 FixtureDef = Any
-SubRequest = Any
 
 
 class PytestAsyncioError(Exception):
@@ -282,7 +281,7 @@ def _add_kwargs(
     kwargs: Dict[str, Any],
     event_loop_fixture_id: str,
     event_loop: asyncio.AbstractEventLoop,
-    request: SubRequest,
+    request: FixtureRequest,
 ) -> Dict[str, Any]:
     sig = inspect.signature(func)
     ret = kwargs.copy()
@@ -316,7 +315,7 @@ def _wrap_asyncgen_fixture(fixturedef: FixtureDef, event_loop_fixture_id: str) -
     fixture = fixturedef.func
 
     @functools.wraps(fixture)
-    def _asyncgen_fixture_wrapper(request: SubRequest, **kwargs: Any):
+    def _asyncgen_fixture_wrapper(request: FixtureRequest, **kwargs: Any):
         func = _perhaps_rebind_fixture_func(
             fixture, request.instance, fixturedef.unittest
         )
@@ -355,7 +354,7 @@ def _wrap_async_fixture(fixturedef: FixtureDef, event_loop_fixture_id: str) -> N
     fixture = fixturedef.func
 
     @functools.wraps(fixture)
-    def _async_fixture_wrapper(request: SubRequest, **kwargs: Any):
+    def _async_fixture_wrapper(request: FixtureRequest, **kwargs: Any):
         func = _perhaps_rebind_fixture_func(
             fixture, request.instance, fixturedef.unittest
         )

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -315,9 +315,8 @@ def _wrap_asyncgen_fixture(fixturedef: FixtureDef, event_loop_fixture_id: str) -
 
     @functools.wraps(fixture)
     def _asyncgen_fixture_wrapper(request: FixtureRequest, **kwargs: Any):
-        func = _perhaps_rebind_fixture_func(
-            fixture, request.instance, fixturedef.unittest
-        )
+        unittest = False if pytest.version_tuple >= (8, 2) else fixturedef.unittest
+        func = _perhaps_rebind_fixture_func(fixture, request.instance, unittest)
         event_loop = kwargs.pop(event_loop_fixture_id)
         gen_obj = func(
             **_add_kwargs(func, kwargs, event_loop_fixture_id, event_loop, request)
@@ -354,9 +353,8 @@ def _wrap_async_fixture(fixturedef: FixtureDef, event_loop_fixture_id: str) -> N
 
     @functools.wraps(fixture)
     def _async_fixture_wrapper(request: FixtureRequest, **kwargs: Any):
-        func = _perhaps_rebind_fixture_func(
-            fixture, request.instance, fixturedef.unittest
-        )
+        unittest = False if pytest.version_tuple >= (8, 2) else fixturedef.unittest
+        func = _perhaps_rebind_fixture_func(fixture, request.instance, unittest)
         event_loop = kwargs.pop(event_loop_fixture_id)
 
         async def setup():


### PR DESCRIPTION
Since pytest 8.2 (still in development) unittest and regular will behave the same, so unittest special handling is no longer needed.

I also added two unrelated cleanup commits I noticed, if you prefer I can remove them.