### PR TITLE
Made 0.21.1 compatible with pytest 8.2.0

### DIFF
--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+0.21.2 (2024-04-29)
+===================
+- Fix compatibility with pytest 8.2. Backport of `#800 <https://github.com/pytest-dev/pytest-asyncio/pull/800>`_ to pytest-asyncio v0.21 for users who are unable to upgrade to a more recent version (see `#706 <https://github.com/pytest-dev/pytest-asyncio/pull/706>`_)
+
 0.21.1 (2023-07-12)
 ===================
 - Output a proper error message when an invalid ``asyncio_mode`` is selected.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -240,7 +240,7 @@ def _add_kwargs(
     func: Callable[..., Any],
     kwargs: Dict[str, Any],
     event_loop: asyncio.AbstractEventLoop,
-    request: SubRequest,
+    request: FixtureRequest,
 ) -> Dict[str, Any]:
     sig = inspect.signature(func)
     ret = kwargs.copy()
@@ -277,9 +277,8 @@ def _wrap_asyncgen_fixture(fixturedef: FixtureDef) -> None:
     def _asyncgen_fixture_wrapper(
         event_loop: asyncio.AbstractEventLoop, request: SubRequest, **kwargs: Any
     ):
-        func = _perhaps_rebind_fixture_func(
-            fixture, request.instance, fixturedef.unittest
-        )
+        unittest = False if pytest.version_tuple >= (8, 2) else fixturedef.unittest
+        func = _perhaps_rebind_fixture_func(fixture, request.instance, unittest)
         gen_obj = func(**_add_kwargs(func, kwargs, event_loop, request))
 
         async def setup():
@@ -315,9 +314,8 @@ def _wrap_async_fixture(fixturedef: FixtureDef) -> None:
     def _async_fixture_wrapper(
         event_loop: asyncio.AbstractEventLoop, request: SubRequest, **kwargs: Any
     ):
-        func = _perhaps_rebind_fixture_func(
-            fixture, request.instance, fixturedef.unittest
-        )
+        unittest = False if pytest.version_tuple >= (8, 2) else fixturedef.unittest
+        func = _perhaps_rebind_fixture_func(fixture, request.instance, unittest)
 
         async def setup():
             res = await func(**_add_kwargs(func, kwargs, event_loop, request))


### PR DESCRIPTION
Backported #800 to the 0.21.1 tag
This unblocks all users stuck with 0.21.1 due to #706

As is, this PR can't be merged. A new branch, created from tag 0.21.1, must be created first. Then the base branch of this PR must be changed to that branch

I've run a few test suites locally and these changes work fine: any feedback is welcome