### PR TITLE
Remove development dependency on Docker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,22 +52,10 @@ repos:
   rev: v1.9.0
   hooks:
   - id: python-use-type-annotations
-- repo: https://github.com/rhysd/actionlint
-  rev: v1.6.22
-  hooks:
-  - id: actionlint-docker
-    args:
-    - -ignore
-    - 'SC2155:'
-    - -ignore
-    - 'SC2086:'
-    - -ignore
-    - 'SC1004:'
 - repo: https://github.com/sirosen/check-jsonschema
   rev: 0.19.2
   hooks:
   - id: check-github-actions
 ci:
   skip:
-  - actionlint-docker
   - check-github-actions


### PR DESCRIPTION
Removes the actionlint-docker pre-commit hook, which requires Docker to be set up on the development machine. Given that the pre-commit hooks already lint yaml files and that the GitHub actions are run for every PR, the Docker dependency seems unreasonable.

closes #595 