### PR TITLE
Clean up GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Run pre-commit checks
       run: pre-commit run --all-files --show-diff-on-failure
     - name: Install check-wheel-content, and twine
-      run: python -m pip install build check-wheel-contents tox twine
+      run: python -m pip install build check-wheel-contents twine
     - name: Build package
       run: python -m build
     - name: List result

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,10 +52,22 @@ repos:
   rev: v1.10.0
   hooks:
   - id: python-use-type-annotations
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.6.22
+  hooks:
+  - id: actionlint-docker
+    args:
+    - -ignore
+    - 'SC2155:'
+    - -ignore
+    - 'SC2086:'
+    - -ignore
+    - 'SC1004:'
 - repo: https://github.com/sirosen/check-jsonschema
   rev: 0.29.1
   hooks:
   - id: check-github-actions
 ci:
   skip:
+  - actionlint-docker
   - check-github-actions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,7 @@ repos:
     - 'SC2086:'
     - -ignore
     - 'SC1004:'
+    stages: [manual]
 - repo: https://github.com/sirosen/check-jsonschema
   rev: 0.29.1
   hooks:


### PR DESCRIPTION
Removes pre-commit steps from the GitHub actions workflow, because the hooks are now executed by pre-commit.ci.