### PR TITLE
Preprocess async fixtures for each event loop

### DIFF
--- a/dependencies/default/requirements.txt
+++ b/dependencies/default/requirements.txt
@@ -1,3 +1,3 @@
 # Always adjust install_requires in setup.cfg and pytest-min-requirements.txt
 # when changing runtime dependencies
-pytest >= 7.0.0,<9
+pytest >= 8.2,<9

--- a/dependencies/pytest-min/constraints.txt
+++ b/dependencies/pytest-min/constraints.txt
@@ -11,10 +11,10 @@ iniconfig==2.0.0
 mock==5.1.0
 nose==1.3.7
 packaging==23.2
-pluggy==1.3.0
+pluggy==1.5.0
 py==1.11.0
 Pygments==2.16.1
-pytest==7.0.0
+pytest==8.2.0
 requests==2.31.0
 sortedcontainers==2.4.0
 tomli==2.0.1

--- a/dependencies/pytest-min/requirements.txt
+++ b/dependencies/pytest-min/requirements.txt
@@ -1,3 +1,3 @@
 # Always adjust install_requires in setup.cfg and requirements.txt
 # when changing minimum version dependencies
-pytest[testing] == 7.0.0
+pytest[testing] == 8.2.0

--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 - Adds an optional `loop_scope` keyword argument to `pytest.mark.asyncio`. This argument controls which event loop is used to run the marked async test. `#706`_, `#871 <https://github.com/pytest-dev/pytest-asyncio/pull/871>`_
 - Deprecates the optional `scope` keyword argument to `pytest.mark.asyncio` for API consistency with ``pytest_asyncio.fixture``. Users are encouraged to use the `loop_scope` keyword argument, which does exactly the same.
 - Raises an error when passing `scope` or `loop_scope` as a positional argument to ``@pytest.mark.asyncio``. `#812 <https://github.com/pytest-dev/pytest-asyncio/issues/812>`_
+- Fixes a bug that caused module-scoped async fixtures to fail when reused in other modules `#862 <https://github.com/pytest-dev/pytest-asyncio/issues/862>`_ `#668 <https://github.com/pytest-dev/pytest-asyncio/issues/668>`_
 
 
 0.23.8 (2024-07-17)

--- a/docs/source/reference/changelog.rst
+++ b/docs/source/reference/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 0.24.0 (UNRELEASED)
 ===================
+- BREAKING: Updated minimum supported pytest version to v8.2.0
 - Adds an optional `loop_scope` keyword argument to `pytest.mark.asyncio`. This argument controls which event loop is used to run the marked async test. `#706`_, `#871 <https://github.com/pytest-dev/pytest-asyncio/pull/871>`_
 - Deprecates the optional `scope` keyword argument to `pytest.mark.asyncio` for API consistency with ``pytest_asyncio.fixture``. Users are encouraged to use the `loop_scope` keyword argument, which does exactly the same.
 - Raises an error when passing `scope` or `loop_scope` as a positional argument to ``@pytest.mark.asyncio``. `#812 <https://github.com/pytest-dev/pytest-asyncio/issues/812>`_

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -756,11 +756,10 @@ def pytest_generate_tests(metafunc: Metafunc) -> None:
         )
 
 
-# TODO: #778 Narrow down return type of function when dropping support for pytest 7
 @pytest.hookimpl(hookwrapper=True)
 def pytest_fixture_setup(
     fixturedef: FixtureDef,
-) -> Generator[None, Any, None]:
+) -> Generator[None, pluggy.Result, None]:
     """Adjust the event loop policy when an event loop is produced."""
     if fixturedef.argname == "event_loop":
         # The use of a fixture finalizer is preferred over the

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -291,9 +291,7 @@ def _add_kwargs(
     return ret
 
 
-def _perhaps_rebind_fixture_func(
-    func: _T, instance: Optional[Any], unittest: bool
-) -> _T:
+def _perhaps_rebind_fixture_func(func: _T, instance: Optional[Any]) -> _T:
     if instance is not None:
         # The fixture needs to be bound to the actual request.instance
         # so it is bound to the same object as the test method.
@@ -302,10 +300,9 @@ def _perhaps_rebind_fixture_func(
             unbound, cls = func.__func__, type(func.__self__)  # type: ignore
         except AttributeError:
             pass
-        # If unittest is true, the fixture is bound unconditionally.
-        # otherwise, only if the fixture was bound before to an instance of
+        # Only if the fixture was bound before to an instance of
         # the same type.
-        if unittest or (cls is not None and isinstance(instance, cls)):
+        if cls is not None and isinstance(instance, cls):
             func = unbound.__get__(instance)  # type: ignore
     return func
 
@@ -315,7 +312,7 @@ def _wrap_asyncgen_fixture(fixturedef: FixtureDef) -> None:
 
     @functools.wraps(fixture)
     def _asyncgen_fixture_wrapper(request: FixtureRequest, **kwargs: Any):
-        func = _perhaps_rebind_fixture_func(fixture, request.instance, False)
+        func = _perhaps_rebind_fixture_func(fixture, request.instance)
         event_loop_fixture_id = _get_event_loop_fixture_id_for_async_fixture(
             request, func
         )
@@ -354,7 +351,7 @@ def _wrap_async_fixture(fixturedef: FixtureDef) -> None:
 
     @functools.wraps(fixture)
     def _async_fixture_wrapper(request: FixtureRequest, **kwargs: Any):
-        func = _perhaps_rebind_fixture_func(fixture, request.instance, False)
+        func = _perhaps_rebind_fixture_func(fixture, request.instance)
         event_loop_fixture_id = _get_event_loop_fixture_id_for_async_fixture(
             request, func
         )

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -30,6 +30,7 @@ from typing import (
     overload,
 )
 
+import pluggy
 import pytest
 from pytest import (
     Class,
@@ -539,13 +540,12 @@ def pytest_pycollect_makeitem_preprocess_async_fixtures(
     return None
 
 
-# TODO: #778 Narrow down return type of function when dropping support for pytest 7
 # The function name needs to start with "pytest_"
 # see https://github.com/pytest-dev/pytest/issues/11307
 @pytest.hookimpl(specname="pytest_pycollect_makeitem", hookwrapper=True)
 def pytest_pycollect_makeitem_convert_async_functions_to_subclass(
     collector: Union[pytest.Module, pytest.Class], name: str, obj: object
-) -> Generator[None, Any, None]:
+) -> Generator[None, pluggy.Result, None]:
     """
     Converts coroutines and async generators collected as pytest.Functions
     to AsyncFunction items.

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ include_package_data = True
 
 # Always adjust requirements.txt and pytest-min-requirements.txt when changing runtime dependencies
 install_requires =
-  pytest >= 7.0.0,<9
+  pytest >= 8.2,<9
 
 [options.extras_require]
 testing =

--- a/tests/async_fixtures/test_shared_module_fixture.py
+++ b/tests/async_fixtures/test_shared_module_fixture.py
@@ -1,0 +1,35 @@
+from textwrap import dedent
+
+from pytest import Pytester
+
+
+def test_asyncio_mark_provides_package_scoped_loop_strict_mode(pytester: Pytester):
+    pytester.makepyfile(
+        __init__="",
+        conftest=dedent(
+            """\
+            import pytest_asyncio
+            @pytest_asyncio.fixture(scope="module")
+            async def async_shared_module_fixture():
+                return True
+            """
+        ),
+        test_module_one=dedent(
+            """\
+            import pytest
+            @pytest.mark.asyncio
+            async def test_shared_module_fixture_use_a(async_shared_module_fixture):
+                assert async_shared_module_fixture is True
+            """
+        ),
+        test_module_two=dedent(
+            """\
+            import pytest
+            @pytest.mark.asyncio
+            async def test_shared_module_fixture_use_b(async_shared_module_fixture):
+                assert async_shared_module_fixture is True
+            """
+        ),
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=2)

--- a/tests/test_is_async_test.py
+++ b/tests/test_is_async_test.py
@@ -1,6 +1,5 @@
 from textwrap import dedent
 
-import pytest
 from pytest import Pytester
 
 
@@ -74,10 +73,7 @@ def test_returns_false_for_unmarked_coroutine_item_in_strict_mode(pytester: Pyte
         )
     )
     result = pytester.runpytest("--asyncio-mode=strict")
-    if pytest.version_tuple < (8,):
-        result.assert_outcomes(skipped=1)
-    else:
-        result.assert_outcomes(failed=1)
+    result.assert_outcomes(failed=1)
 
 
 def test_returns_true_for_unmarked_coroutine_item_in_auto_mode(pytester: Pytester):

--- a/tests/test_is_async_test.py
+++ b/tests/test_is_async_test.py
@@ -74,10 +74,7 @@ def test_returns_false_for_unmarked_coroutine_item_in_strict_mode(pytester: Pyte
         )
     )
     result = pytester.runpytest("--asyncio-mode=strict")
-    if pytest.version_tuple < (7, 2):
-        # Probably related to https://github.com/pytest-dev/pytest/pull/10012
-        result.assert_outcomes(failed=1)
-    elif pytest.version_tuple < (8,):
+    if pytest.version_tuple < (8,):
         result.assert_outcomes(skipped=1)
     else:
         result.assert_outcomes(failed=1)


### PR DESCRIPTION
Caching of fixture preprocessing is now also keyed by event loop id, sync fixtures can be processed if they are wrapping a async fixture, each async fixture has a mapping from root scope name to fixture id that is now used to dynamically get the event loop fixture.

3 tests fail for me locally, 2 more are flaky, some of these fail without my changes.

I'm note sure if I'm conflating fixture and loop scope and if that is contributing to the failed tests.

I feel like I have not written the clearest code but can only see a broader refactoring as a way out of that and would like feedback if this approach is even something worth doing before undertaking that.

This fixes #862.

@seifertm 