### PR TITLE
Derive project version using importlib

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,3 +16,4 @@ python:
   install:
   - requirements: dependencies/default/constraints.txt
   - requirements: dependencies/docs/constraints.txt
+  - path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,10 +6,12 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import importlib.metadata
+
 project = "pytest-asyncio"
 copyright = "2023, pytest-asyncio contributors"
 author = "Tin Tvrtković"
-release = "v0.23.0"
+release = importlib.metadata.version(project)
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
Fixes #628 

Using `importlib` to populate the version field in `conf.py`