### PR TITLE
Address warning about missing default fixture loop scope in tests

### DIFF
--- a/docs/reference/markers/class_scoped_loop_with_fixture_strict_mode_example.py
+++ b/docs/reference/markers/class_scoped_loop_with_fixture_strict_mode_example.py
@@ -9,7 +9,7 @@ import pytest_asyncio
 class TestClassScopedLoop:
     loop: asyncio.AbstractEventLoop
 
-    @pytest_asyncio.fixture(scope="class")
+    @pytest_asyncio.fixture(loop_scope="class")
     async def my_fixture(self):
         TestClassScopedLoop.loop = asyncio.get_running_loop()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ python_files = test_*.py *_example.py
 addopts = -rsx --tb=short
 testpaths = docs tests
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
 junit_family=xunit2
 filterwarnings =
   error

--- a/tests/async_fixtures/test_async_fixtures_with_finalizer.py
+++ b/tests/async_fixtures/test_async_fixtures_with_finalizer.py
@@ -3,6 +3,8 @@ import functools
 
 import pytest
 
+import pytest_asyncio
+
 
 @pytest.mark.asyncio(loop_scope="module")
 async def test_module_with_event_loop_finalizer(port_with_event_loop_finalizer):
@@ -25,7 +27,7 @@ def event_loop():
     loop.close()
 
 
-@pytest.fixture(scope="module")
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
 async def port_with_event_loop_finalizer(request):
     def port_finalizer(finalizer):
         async def port_afinalizer():
@@ -40,7 +42,7 @@ async def port_with_event_loop_finalizer(request):
     return True
 
 
-@pytest.fixture(scope="module")
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
 async def port_with_get_event_loop_finalizer(request):
     def port_finalizer(finalizer):
         async def port_afinalizer():

--- a/tests/async_fixtures/test_shared_module_fixture.py
+++ b/tests/async_fixtures/test_shared_module_fixture.py
@@ -4,12 +4,13 @@ from pytest import Pytester
 
 
 def test_asyncio_mark_provides_package_scoped_loop_strict_mode(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         conftest=dedent(
             """\
             import pytest_asyncio
-            @pytest_asyncio.fixture(scope="module")
+            @pytest_asyncio.fixture(loop_scope="module", scope="module")
             async def async_shared_module_fixture():
                 return True
             """

--- a/tests/hypothesis/test_base.py
+++ b/tests/hypothesis/test_base.py
@@ -10,6 +10,7 @@ from pytest import Pytester
 
 
 def test_hypothesis_given_decorator_before_asyncio_mark(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -42,6 +43,7 @@ async def test_mark_and_parametrize(x, y):
 
 
 def test_can_use_explicit_event_loop_fixture(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = module")
     pytester.makepyfile(
         dedent(
             """\
@@ -78,6 +80,7 @@ def test_can_use_explicit_event_loop_fixture(pytester: Pytester):
 
 
 def test_async_auto_marked(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -100,6 +103,7 @@ def test_async_auto_marked(pytester: Pytester):
 
 def test_sync_not_auto_marked(pytester: Pytester):
     """Assert that synchronous Hypothesis functions are not marked with asyncio"""
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\

--- a/tests/markers/test_class_scope.py
+++ b/tests/markers/test_class_scope.py
@@ -30,6 +30,7 @@ def sample_fixture():
 def test_asyncio_mark_provides_class_scoped_loop_when_applied_to_functions(
     pytester: pytest.Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -56,6 +57,7 @@ def test_asyncio_mark_provides_class_scoped_loop_when_applied_to_functions(
 def test_asyncio_mark_provides_class_scoped_loop_when_applied_to_class(
     pytester: pytest.Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -81,6 +83,7 @@ def test_asyncio_mark_provides_class_scoped_loop_when_applied_to_class(
 def test_asyncio_mark_raises_when_class_scoped_is_request_without_class(
     pytester: pytest.Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -101,6 +104,7 @@ def test_asyncio_mark_raises_when_class_scoped_is_request_without_class(
 
 
 def test_asyncio_mark_is_inherited_to_subclasses(pytester: pytest.Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -129,6 +133,7 @@ def test_asyncio_mark_is_inherited_to_subclasses(pytester: pytest.Pytester):
 def test_asyncio_mark_respects_the_loop_policy(
     pytester: pytest.Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -166,6 +171,7 @@ def test_asyncio_mark_respects_the_loop_policy(
 def test_asyncio_mark_respects_parametrized_loop_policies(
     pytester: pytest.Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -197,6 +203,7 @@ def test_asyncio_mark_respects_parametrized_loop_policies(
 def test_asyncio_mark_provides_class_scoped_loop_to_fixtures(
     pytester: pytest.Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -226,6 +233,7 @@ def test_asyncio_mark_provides_class_scoped_loop_to_fixtures(
 def test_asyncio_mark_allows_combining_class_scoped_fixture_with_function_scoped_test(
     pytester: pytest.Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -237,7 +245,7 @@ def test_asyncio_mark_allows_combining_class_scoped_fixture_with_function_scoped
             loop: asyncio.AbstractEventLoop
 
             class TestMixedScopes:
-                @pytest_asyncio.fixture(scope="class")
+                @pytest_asyncio.fixture(loop_scope="class", scope="class")
                 async def async_fixture(self):
                     global loop
                     loop = asyncio.get_running_loop()
@@ -257,6 +265,7 @@ def test_asyncio_mark_allows_combining_class_scoped_fixture_with_function_scoped
 def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     pytester: pytest.Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -292,6 +301,7 @@ def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
 def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_being_set(
     pytester: pytest.Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\

--- a/tests/markers/test_function_scope.py
+++ b/tests/markers/test_function_scope.py
@@ -4,6 +4,7 @@ from pytest import Pytester
 
 
 def test_asyncio_mark_provides_function_scoped_loop_strict_mode(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -29,6 +30,7 @@ def test_asyncio_mark_provides_function_scoped_loop_strict_mode(pytester: Pytest
 
 
 def test_loop_scope_function_provides_function_scoped_event_loop(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -54,6 +56,7 @@ def test_loop_scope_function_provides_function_scoped_event_loop(pytester: Pytes
 
 
 def test_raises_when_scope_and_loop_scope_arguments_are_present(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -70,6 +73,7 @@ def test_raises_when_scope_and_loop_scope_arguments_are_present(pytester: Pytest
 
 
 def test_warns_when_scope_argument_is_present(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -89,6 +93,7 @@ def test_warns_when_scope_argument_is_present(pytester: Pytester):
 def test_function_scope_supports_explicit_event_loop_fixture_request(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -111,6 +116,7 @@ def test_function_scope_supports_explicit_event_loop_fixture_request(
 def test_asyncio_mark_respects_the_loop_policy(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -141,6 +147,7 @@ def test_asyncio_mark_respects_the_loop_policy(
 def test_asyncio_mark_respects_parametrized_loop_policies(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -178,6 +185,7 @@ def test_asyncio_mark_respects_parametrized_loop_policies(
 def test_asyncio_mark_provides_function_scoped_loop_to_fixtures(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -208,6 +216,7 @@ def test_asyncio_mark_provides_function_scoped_loop_to_fixtures(
 def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -242,6 +251,7 @@ def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
 def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_being_set(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -260,6 +270,7 @@ def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_be
 def test_asyncio_mark_does_not_duplicate_other_marks_in_auto_mode(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makeconftest(
         dedent(
             """\

--- a/tests/markers/test_module_scope.py
+++ b/tests/markers/test_module_scope.py
@@ -4,6 +4,7 @@ from pytest import Pytester
 
 
 def test_asyncio_mark_works_on_module_level(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -56,6 +57,7 @@ def test_asyncio_mark_works_on_module_level(pytester: Pytester):
 
 
 def test_asyncio_mark_provides_module_scoped_loop_strict_mode(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -88,6 +90,7 @@ def test_asyncio_mark_provides_module_scoped_loop_strict_mode(pytester: Pytester
 def test_raise_when_event_loop_fixture_is_requested_in_addition_to_scoped_loop(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -109,6 +112,7 @@ def test_raise_when_event_loop_fixture_is_requested_in_addition_to_scoped_loop(
 def test_asyncio_mark_respects_the_loop_policy(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         custom_policy=dedent(
@@ -163,6 +167,7 @@ def test_asyncio_mark_respects_the_loop_policy(
 def test_asyncio_mark_respects_parametrized_loop_policies(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -194,6 +199,7 @@ def test_asyncio_mark_respects_parametrized_loop_policies(
 def test_asyncio_mark_provides_module_scoped_loop_to_fixtures(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -206,7 +212,7 @@ def test_asyncio_mark_provides_module_scoped_loop_to_fixtures(
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="module")
+            @pytest_asyncio.fixture(loop_scope="module", scope="module")
             async def my_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -224,6 +230,7 @@ def test_asyncio_mark_provides_module_scoped_loop_to_fixtures(
 def test_asyncio_mark_allows_combining_module_scoped_fixture_with_class_scoped_test(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -234,7 +241,7 @@ def test_asyncio_mark_allows_combining_module_scoped_fixture_with_class_scoped_t
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="module")
+            @pytest_asyncio.fixture(loop_scope="module", scope="module")
             async def async_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -255,6 +262,7 @@ def test_asyncio_mark_allows_combining_module_scoped_fixture_with_class_scoped_t
 def test_asyncio_mark_allows_combining_module_scoped_fixture_with_function_scoped_test(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_mixed_scopes=dedent(
@@ -266,7 +274,7 @@ def test_asyncio_mark_allows_combining_module_scoped_fixture_with_function_scope
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="module")
+            @pytest_asyncio.fixture(loop_scope="module", scope="module")
             async def async_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -285,6 +293,7 @@ def test_asyncio_mark_allows_combining_module_scoped_fixture_with_function_scope
 def test_allows_combining_module_scoped_asyncgen_fixture_with_function_scoped_test(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -295,7 +304,7 @@ def test_allows_combining_module_scoped_asyncgen_fixture_with_function_scoped_te
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="module")
+            @pytest_asyncio.fixture(loop_scope="module", scope="module")
             async def async_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -315,6 +324,7 @@ def test_allows_combining_module_scoped_asyncgen_fixture_with_function_scoped_te
 def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -349,6 +359,7 @@ def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
 def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_being_set(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\

--- a/tests/markers/test_package_scope.py
+++ b/tests/markers/test_package_scope.py
@@ -6,6 +6,7 @@ from pytest import Pytester
 def test_asyncio_mark_provides_package_scoped_loop_strict_mode(pytester: Pytester):
     package_name = pytester.path.name
     subpackage_name = "subpkg"
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         shared_module=dedent(
@@ -69,6 +70,7 @@ def test_asyncio_mark_provides_package_scoped_loop_strict_mode(pytester: Pyteste
 def test_raise_when_event_loop_fixture_is_requested_in_addition_to_scoped_loop(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_raises=dedent(
@@ -90,6 +92,7 @@ def test_raise_when_event_loop_fixture_is_requested_in_addition_to_scoped_loop(
 def test_asyncio_mark_respects_the_loop_policy(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         conftest=dedent(
@@ -151,6 +154,7 @@ def test_asyncio_mark_respects_the_loop_policy(
 def test_asyncio_mark_respects_parametrized_loop_policies(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_parametrization=dedent(
@@ -183,6 +187,7 @@ def test_asyncio_mark_respects_parametrized_loop_policies(
 def test_asyncio_mark_provides_package_scoped_loop_to_fixtures(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     package_name = pytester.path.name
     pytester.makepyfile(
         __init__="",
@@ -194,7 +199,7 @@ def test_asyncio_mark_provides_package_scoped_loop_to_fixtures(
 
             from {package_name} import shared_module
 
-            @pytest_asyncio.fixture(scope="package")
+            @pytest_asyncio.fixture(loop_scope="package", scope="package")
             async def my_fixture():
                 shared_module.loop = asyncio.get_running_loop()
             """
@@ -229,6 +234,7 @@ def test_asyncio_mark_provides_package_scoped_loop_to_fixtures(
 def test_asyncio_mark_allows_combining_package_scoped_fixture_with_module_scoped_test(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_mixed_scopes=dedent(
@@ -240,7 +246,7 @@ def test_asyncio_mark_allows_combining_package_scoped_fixture_with_module_scoped
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="package")
+            @pytest_asyncio.fixture(loop_scope="package", scope="package")
             async def async_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -259,6 +265,7 @@ def test_asyncio_mark_allows_combining_package_scoped_fixture_with_module_scoped
 def test_asyncio_mark_allows_combining_package_scoped_fixture_with_class_scoped_test(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_mixed_scopes=dedent(
@@ -270,7 +277,7 @@ def test_asyncio_mark_allows_combining_package_scoped_fixture_with_class_scoped_
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="package")
+            @pytest_asyncio.fixture(loop_scope="package", scope="package")
             async def async_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -290,6 +297,7 @@ def test_asyncio_mark_allows_combining_package_scoped_fixture_with_class_scoped_
 def test_asyncio_mark_allows_combining_package_scoped_fixture_with_function_scoped_test(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_mixed_scopes=dedent(
@@ -301,7 +309,7 @@ def test_asyncio_mark_allows_combining_package_scoped_fixture_with_function_scop
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="package")
+            @pytest_asyncio.fixture(loop_scope="package", scope="package")
             async def async_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -320,6 +328,7 @@ def test_asyncio_mark_allows_combining_package_scoped_fixture_with_function_scop
 def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_loop_is_none=dedent(
@@ -355,6 +364,7 @@ def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
 def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_being_set(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_module=dedent(

--- a/tests/markers/test_session_scope.py
+++ b/tests/markers/test_session_scope.py
@@ -5,6 +5,7 @@ from pytest import Pytester
 
 def test_asyncio_mark_provides_session_scoped_loop_strict_mode(pytester: Pytester):
     package_name = pytester.path.name
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         shared_module=dedent(
@@ -70,6 +71,7 @@ def test_asyncio_mark_provides_session_scoped_loop_strict_mode(pytester: Pyteste
 def test_raise_when_event_loop_fixture_is_requested_in_addition_to_scoped_loop(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_raises=dedent(
@@ -91,6 +93,7 @@ def test_raise_when_event_loop_fixture_is_requested_in_addition_to_scoped_loop(
 def test_asyncio_mark_respects_the_loop_policy(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         conftest=dedent(
@@ -152,6 +155,7 @@ def test_asyncio_mark_respects_the_loop_policy(
 def test_asyncio_mark_respects_parametrized_loop_policies(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_parametrization=dedent(
@@ -185,6 +189,7 @@ def test_asyncio_mark_provides_session_scoped_loop_to_fixtures(
     pytester: Pytester,
 ):
     package_name = pytester.path.name
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         conftest=dedent(
@@ -195,7 +200,7 @@ def test_asyncio_mark_provides_session_scoped_loop_to_fixtures(
 
             from {package_name} import shared_module
 
-            @pytest_asyncio.fixture(scope="session")
+            @pytest_asyncio.fixture(loop_scope="session", scope="session")
             async def my_fixture():
                 shared_module.loop = asyncio.get_running_loop()
             """
@@ -234,6 +239,7 @@ def test_asyncio_mark_provides_session_scoped_loop_to_fixtures(
 def test_asyncio_mark_allows_combining_session_scoped_fixture_with_package_scoped_test(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_mixed_scopes=dedent(
@@ -245,7 +251,7 @@ def test_asyncio_mark_allows_combining_session_scoped_fixture_with_package_scope
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="session")
+            @pytest_asyncio.fixture(loop_scope="session", scope="session")
             async def async_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -264,6 +270,7 @@ def test_asyncio_mark_allows_combining_session_scoped_fixture_with_package_scope
 def test_asyncio_mark_allows_combining_session_scoped_fixture_with_module_scoped_test(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_mixed_scopes=dedent(
@@ -275,7 +282,7 @@ def test_asyncio_mark_allows_combining_session_scoped_fixture_with_module_scoped
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="session")
+            @pytest_asyncio.fixture(loop_scope="session", scope="session")
             async def async_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -294,6 +301,7 @@ def test_asyncio_mark_allows_combining_session_scoped_fixture_with_module_scoped
 def test_asyncio_mark_allows_combining_session_scoped_fixture_with_class_scoped_test(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_mixed_scopes=dedent(
@@ -305,7 +313,7 @@ def test_asyncio_mark_allows_combining_session_scoped_fixture_with_class_scoped_
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="session")
+            @pytest_asyncio.fixture(loop_scope="session", scope="session")
             async def async_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -325,6 +333,7 @@ def test_asyncio_mark_allows_combining_session_scoped_fixture_with_class_scoped_
 def test_asyncio_mark_allows_combining_session_scoped_fixture_with_function_scoped_test(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_mixed_scopes=dedent(
@@ -336,7 +345,7 @@ def test_asyncio_mark_allows_combining_session_scoped_fixture_with_function_scop
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="session")
+            @pytest_asyncio.fixture(loop_scope="session", scope="session")
             async def async_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -355,6 +364,7 @@ def test_asyncio_mark_allows_combining_session_scoped_fixture_with_function_scop
 def test_allows_combining_session_scoped_asyncgen_fixture_with_function_scoped_test(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_mixed_scopes=dedent(
@@ -366,7 +376,7 @@ def test_allows_combining_session_scoped_asyncgen_fixture_with_function_scoped_t
 
             loop: asyncio.AbstractEventLoop
 
-            @pytest_asyncio.fixture(scope="session")
+            @pytest_asyncio.fixture(loop_scope="session", scope="session")
             async def async_fixture():
                 global loop
                 loop = asyncio.get_running_loop()
@@ -386,6 +396,7 @@ def test_allows_combining_session_scoped_asyncgen_fixture_with_function_scoped_t
 def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -420,6 +431,7 @@ def test_asyncio_mark_handles_missing_event_loop_triggered_by_fixture(
 def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_being_set(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\

--- a/tests/modes/test_auto_mode.py
+++ b/tests/modes/test_auto_mode.py
@@ -1,8 +1,10 @@
 from textwrap import dedent
 
+from pytest import Pytester
 
-def test_auto_mode_cmdline(testdir):
-    testdir.makepyfile(
+
+def test_auto_mode_cmdline(pytester: Pytester):
+    pytester.makepyfile(
         dedent(
             """\
         import asyncio
@@ -15,12 +17,12 @@ def test_auto_mode_cmdline(testdir):
         """
         )
     )
-    result = testdir.runpytest("--asyncio-mode=auto")
+    result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(passed=1)
 
 
-def test_auto_mode_cfg(testdir):
-    testdir.makepyfile(
+def test_auto_mode_cfg(pytester: Pytester):
+    pytester.makepyfile(
         dedent(
             """\
         import asyncio
@@ -33,13 +35,13 @@ def test_auto_mode_cfg(testdir):
         """
         )
     )
-    testdir.makefile(".ini", pytest="[pytest]\nasyncio_mode = auto\n")
-    result = testdir.runpytest()
+    pytester.makefile(".ini", pytest="[pytest]\nasyncio_mode = auto\n")
+    result = pytester.runpytest()
     result.assert_outcomes(passed=1)
 
 
-def test_auto_mode_async_fixture(testdir):
-    testdir.makepyfile(
+def test_auto_mode_async_fixture(pytester: Pytester):
+    pytester.makepyfile(
         dedent(
             """\
         import asyncio
@@ -58,12 +60,12 @@ def test_auto_mode_async_fixture(testdir):
         """
         )
     )
-    result = testdir.runpytest("--asyncio-mode=auto")
+    result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(passed=1)
 
 
-def test_auto_mode_method_fixture(testdir):
-    testdir.makepyfile(
+def test_auto_mode_method_fixture(pytester: Pytester):
+    pytester.makepyfile(
         dedent(
             """\
         import asyncio
@@ -85,12 +87,12 @@ def test_auto_mode_method_fixture(testdir):
         """
         )
     )
-    result = testdir.runpytest("--asyncio-mode=auto")
+    result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(passed=1)
 
 
-def test_auto_mode_static_method(testdir):
-    testdir.makepyfile(
+def test_auto_mode_static_method(pytester: Pytester):
+    pytester.makepyfile(
         dedent(
             """\
         import asyncio
@@ -106,12 +108,12 @@ def test_auto_mode_static_method(testdir):
         """
         )
     )
-    result = testdir.runpytest("--asyncio-mode=auto")
+    result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(passed=1)
 
 
-def test_auto_mode_static_method_fixture(testdir):
-    testdir.makepyfile(
+def test_auto_mode_static_method_fixture(pytester: Pytester):
+    pytester.makepyfile(
         dedent(
             """\
         import asyncio
@@ -135,5 +137,5 @@ def test_auto_mode_static_method_fixture(testdir):
         """
         )
     )
-    result = testdir.runpytest("--asyncio-mode=auto")
+    result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(passed=1)

--- a/tests/modes/test_auto_mode.py
+++ b/tests/modes/test_auto_mode.py
@@ -4,6 +4,7 @@ from pytest import Pytester
 
 
 def test_auto_mode_cmdline(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -22,6 +23,15 @@ def test_auto_mode_cmdline(pytester: Pytester):
 
 
 def test_auto_mode_cfg(pytester: Pytester):
+    pytester.makeini(
+        dedent(
+            """\
+            [pytest]
+            asyncio_default_fixture_loop_scope = function
+            asyncio_mode = auto
+            """
+        )
+    )
     pytester.makepyfile(
         dedent(
             """\
@@ -35,12 +45,12 @@ def test_auto_mode_cfg(pytester: Pytester):
         """
         )
     )
-    pytester.makefile(".ini", pytest="[pytest]\nasyncio_mode = auto\n")
-    result = pytester.runpytest()
+    result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(passed=1)
 
 
 def test_auto_mode_async_fixture(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -65,6 +75,7 @@ def test_auto_mode_async_fixture(pytester: Pytester):
 
 
 def test_auto_mode_method_fixture(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -92,6 +103,7 @@ def test_auto_mode_method_fixture(pytester: Pytester):
 
 
 def test_auto_mode_static_method(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -113,6 +125,7 @@ def test_auto_mode_static_method(pytester: Pytester):
 
 
 def test_auto_mode_static_method_fixture(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\

--- a/tests/modes/test_strict_mode.py
+++ b/tests/modes/test_strict_mode.py
@@ -4,6 +4,7 @@ from pytest import Pytester
 
 
 def test_strict_mode_cmdline(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -23,6 +24,15 @@ def test_strict_mode_cmdline(pytester: Pytester):
 
 
 def test_strict_mode_cfg(pytester: Pytester):
+    pytester.makeini(
+        dedent(
+            """\
+            [pytest]
+            asyncio_default_fixture_loop_scope = function
+            asyncio_mode = strict
+            """
+        )
+    )
     pytester.makepyfile(
         dedent(
             """\
@@ -37,12 +47,12 @@ def test_strict_mode_cfg(pytester: Pytester):
         """
         )
     )
-    pytester.makefile(".ini", pytest="[pytest]\nasyncio_mode = strict\n")
     result = pytester.runpytest()
     result.assert_outcomes(passed=1)
 
 
 def test_strict_mode_method_fixture(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -71,6 +81,7 @@ def test_strict_mode_method_fixture(pytester: Pytester):
 
 
 def test_strict_mode_ignores_unmarked_coroutine(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -87,6 +98,7 @@ def test_strict_mode_ignores_unmarked_coroutine(pytester: Pytester):
 
 
 def test_strict_mode_ignores_unmarked_fixture(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\

--- a/tests/modes/test_strict_mode.py
+++ b/tests/modes/test_strict_mode.py
@@ -1,8 +1,10 @@
 from textwrap import dedent
 
+from pytest import Pytester
 
-def test_strict_mode_cmdline(testdir):
-    testdir.makepyfile(
+
+def test_strict_mode_cmdline(pytester: Pytester):
+    pytester.makepyfile(
         dedent(
             """\
         import asyncio
@@ -16,12 +18,12 @@ def test_strict_mode_cmdline(testdir):
         """
         )
     )
-    result = testdir.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict")
     result.assert_outcomes(passed=1)
 
 
-def test_strict_mode_cfg(testdir):
-    testdir.makepyfile(
+def test_strict_mode_cfg(pytester: Pytester):
+    pytester.makepyfile(
         dedent(
             """\
         import asyncio
@@ -35,13 +37,13 @@ def test_strict_mode_cfg(testdir):
         """
         )
     )
-    testdir.makefile(".ini", pytest="[pytest]\nasyncio_mode = strict\n")
-    result = testdir.runpytest()
+    pytester.makefile(".ini", pytest="[pytest]\nasyncio_mode = strict\n")
+    result = pytester.runpytest()
     result.assert_outcomes(passed=1)
 
 
-def test_strict_mode_method_fixture(testdir):
-    testdir.makepyfile(
+def test_strict_mode_method_fixture(pytester: Pytester):
+    pytester.makepyfile(
         dedent(
             """\
         import asyncio
@@ -64,12 +66,12 @@ def test_strict_mode_method_fixture(testdir):
         """
         )
     )
-    result = testdir.runpytest("--asyncio-mode=auto")
+    result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(passed=1)
 
 
-def test_strict_mode_ignores_unmarked_coroutine(testdir):
-    testdir.makepyfile(
+def test_strict_mode_ignores_unmarked_coroutine(pytester: Pytester):
+    pytester.makepyfile(
         dedent(
             """\
         import pytest
@@ -79,13 +81,13 @@ def test_strict_mode_ignores_unmarked_coroutine(testdir):
         """
         )
     )
-    result = testdir.runpytest_subprocess("--asyncio-mode=strict", "-W default")
+    result = pytester.runpytest_subprocess("--asyncio-mode=strict", "-W default")
     result.assert_outcomes(skipped=1, warnings=1)
     result.stdout.fnmatch_lines(["*async def functions are not natively supported*"])
 
 
-def test_strict_mode_ignores_unmarked_fixture(testdir):
-    testdir.makepyfile(
+def test_strict_mode_ignores_unmarked_fixture(pytester: Pytester):
+    pytester.makepyfile(
         dedent(
             """\
         import pytest
@@ -100,7 +102,7 @@ def test_strict_mode_ignores_unmarked_fixture(testdir):
         """
         )
     )
-    result = testdir.runpytest_subprocess("--asyncio-mode=strict", "-W default")
+    result = pytester.runpytest_subprocess("--asyncio-mode=strict", "-W default")
     result.assert_outcomes(skipped=1, warnings=2)
     result.stdout.fnmatch_lines(
         [

--- a/tests/test_asyncio_fixture.py
+++ b/tests/test_asyncio_fixture.py
@@ -2,6 +2,7 @@ import asyncio
 from textwrap import dedent
 
 import pytest
+from pytest import Pytester
 
 import pytest_asyncio
 
@@ -43,8 +44,9 @@ async def test_fixture_with_params(fixture_with_params):
 
 
 @pytest.mark.parametrize("mode", ("auto", "strict"))
-def test_sync_function_uses_async_fixture(testdir, mode):
-    testdir.makepyfile(
+def test_sync_function_uses_async_fixture(pytester: Pytester, mode):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(
         dedent(
             """\
         import pytest_asyncio
@@ -60,5 +62,5 @@ def test_sync_function_uses_async_fixture(testdir, mode):
         """
         )
     )
-    result = testdir.runpytest(f"--asyncio-mode={mode}")
+    result = pytester.runpytest(f"--asyncio-mode={mode}")
     result.assert_outcomes(passed=1)

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -4,6 +4,7 @@ from pytest import Pytester
 
 
 def test_plugin_does_not_interfere_with_doctest_collection(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             '''\
@@ -20,6 +21,7 @@ def test_plugin_does_not_interfere_with_doctest_collection(pytester: Pytester):
 
 
 def test_plugin_does_not_interfere_with_doctest_textfile_collection(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makefile(".txt", "")  # collected as DoctestTextfile
     pytester.makepyfile(
         __init__="",

--- a/tests/test_event_loop_fixture_finalizer.py
+++ b/tests/test_event_loop_fixture_finalizer.py
@@ -4,6 +4,7 @@ from pytest import Pytester
 
 
 def test_event_loop_fixture_finalizer_returns_fresh_loop_after_test(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -36,6 +37,7 @@ def test_event_loop_fixture_finalizer_returns_fresh_loop_after_test(pytester: Py
 def test_event_loop_fixture_finalizer_handles_loop_set_to_none_sync(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -53,6 +55,7 @@ def test_event_loop_fixture_finalizer_handles_loop_set_to_none_sync(
 def test_event_loop_fixture_finalizer_handles_loop_set_to_none_async_without_fixture(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -72,6 +75,7 @@ def test_event_loop_fixture_finalizer_handles_loop_set_to_none_async_without_fix
 def test_event_loop_fixture_finalizer_handles_loop_set_to_none_async_with_fixture(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -94,6 +98,7 @@ def test_event_loop_fixture_finalizer_handles_loop_set_to_none_async_with_fixtur
 def test_event_loop_fixture_finalizer_raises_warning_when_fixture_leaves_loop_unclosed(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -121,6 +126,7 @@ def test_event_loop_fixture_finalizer_raises_warning_when_fixture_leaves_loop_un
 def test_event_loop_fixture_finalizer_raises_warning_when_test_leaves_loop_unclosed(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\

--- a/tests/test_explicit_event_loop_fixture_request.py
+++ b/tests/test_explicit_event_loop_fixture_request.py
@@ -6,6 +6,7 @@ from pytest import Pytester
 def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -27,6 +28,7 @@ def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine(
 def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine_method(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -49,6 +51,7 @@ def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine_metho
 def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine_staticmethod(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -72,6 +75,7 @@ def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine_stati
 def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine_fixture(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -98,6 +102,7 @@ def test_emit_warning_when_event_loop_is_explicitly_requested_in_coroutine_fixtu
 def test_emit_warning_when_event_loop_is_explicitly_requested_in_async_gen_fixture(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -124,6 +129,7 @@ def test_emit_warning_when_event_loop_is_explicitly_requested_in_async_gen_fixtu
 def test_does_not_emit_warning_when_event_loop_is_explicitly_requested_in_sync_function(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -141,6 +147,7 @@ def test_does_not_emit_warning_when_event_loop_is_explicitly_requested_in_sync_f
 def test_does_not_emit_warning_when_event_loop_is_explicitly_requested_in_sync_fixture(
     pytester: Pytester,
 ):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -4,6 +4,7 @@ from pytest import Pytester
 
 
 def test_import_warning_does_not_cause_internal_error(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -19,6 +20,7 @@ def test_import_warning_does_not_cause_internal_error(pytester: Pytester):
 
 
 def test_import_warning_in_package_does_not_cause_internal_error(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__=dedent(
             """\
@@ -37,6 +39,7 @@ def test_import_warning_in_package_does_not_cause_internal_error(pytester: Pytes
 
 
 def test_does_not_import_unrelated_packages(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pkg_dir = pytester.mkpydir("mypkg")
     pkg_dir.joinpath("__init__.py").write_text(
         dedent(

--- a/tests/test_is_async_test.py
+++ b/tests/test_is_async_test.py
@@ -4,6 +4,7 @@ from pytest import Pytester
 
 
 def test_returns_false_for_sync_item(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -28,6 +29,7 @@ def test_returns_false_for_sync_item(pytester: Pytester):
 
 
 def test_returns_true_for_marked_coroutine_item_in_strict_mode(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -53,6 +55,7 @@ def test_returns_true_for_marked_coroutine_item_in_strict_mode(pytester: Pyteste
 
 
 def test_returns_false_for_unmarked_coroutine_item_in_strict_mode(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -77,6 +80,7 @@ def test_returns_false_for_unmarked_coroutine_item_in_strict_mode(pytester: Pyte
 
 
 def test_returns_true_for_unmarked_coroutine_item_in_auto_mode(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -26,6 +26,7 @@ async def test_asyncio_marker():
 
 
 def test_asyncio_marker_compatibility_with_xfail(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -45,6 +46,7 @@ def test_asyncio_marker_compatibility_with_xfail(pytester: Pytester):
 
 
 def test_asyncio_auto_mode_compatibility_with_xfail(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -101,8 +103,9 @@ class TestEventLoopStartedBeforeFixtures:
         assert await loop.run_in_executor(None, self.foo) == 1
 
 
-def test_invalid_asyncio_mode(testdir):
-    result = testdir.runpytest("-o", "asyncio_mode=True")
+def test_invalid_asyncio_mode(pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    result = pytester.runpytest("-o", "asyncio_mode=True")
     result.stderr.no_fnmatch_line("INTERNALERROR> *")
     result.stderr.fnmatch_lines(
         "ERROR: 'True' is not a valid asyncio_mode. Valid modes: auto, strict."

--- a/tests/test_skips.py
+++ b/tests/test_skips.py
@@ -4,6 +4,7 @@ from pytest import Pytester
 
 
 def test_asyncio_strict_mode_skip(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -22,6 +23,7 @@ def test_asyncio_strict_mode_skip(pytester: Pytester):
 
 
 def test_asyncio_auto_mode_skip(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -39,6 +41,7 @@ def test_asyncio_auto_mode_skip(pytester: Pytester):
 
 
 def test_asyncio_strict_mode_module_level_skip(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -57,6 +60,7 @@ def test_asyncio_strict_mode_module_level_skip(pytester: Pytester):
 
 
 def test_asyncio_auto_mode_module_level_skip(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -74,6 +78,7 @@ def test_asyncio_auto_mode_module_level_skip(pytester: Pytester):
 
 
 def test_asyncio_auto_mode_wrong_skip_usage(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -91,6 +96,7 @@ def test_asyncio_auto_mode_wrong_skip_usage(pytester: Pytester):
 
 
 def test_unittest_skiptest_compatibility(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         dedent(
             """\
@@ -108,6 +114,7 @@ def test_unittest_skiptest_compatibility(pytester: Pytester):
 
 
 def test_skip_in_module_does_not_skip_package(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
         __init__="",
         test_skip=dedent(


### PR DESCRIPTION
Addresses all warnings in the pytest-asyncio test suite caused by the introduction of the_asyncio_fixture_loop_scope_ configuration option (see https://github.com/pytest-dev/pytest-asyncio/pull/871).