### PR TITLE
Address invisible hidden files in artifact upload action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
       if: "!endsWith(matrix.os, 'windows')"
       with:
         name: coverage-python-${{ matrix.python-version }}
-        path: .coverage.*
+        path: coverage/coverage.*
         if-no-files-found: error
 
   check:
@@ -113,6 +113,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         pattern: coverage-*
+        path: coverage
         merge-multiple: true
     - name: Combine coverage data and create report
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,7 @@ jobs:
       with:
         name: coverage-python-${{ matrix.python-version }}
         path: .coverage.*
+        if-no-files-found: error
 
   check:
     name: Check

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-.coverage
-.coverage.*
+coverage/
 .pytest_cache
 nosetests.xml
 coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean-pyc: ## remove Python file artifacts
 
 clean-test: ## remove test and coverage artifacts
 	rm -fr .tox/
-	rm -f .coverage
+	rm -fr coverage/
 	rm -fr htmlcov/
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 
 test:
-	coverage run --parallel-mode -m pytest
+	coverage run -m pytest
 
 install:
 	pip install -U pre-commit

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 
 test:
-	coverage run --parallel-mode --omit */_version.py -m pytest
+	coverage run --parallel-mode -m pytest
 
 install:
 	pip install -U pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ pytest11 =
 [coverage:run]
 source = pytest_asyncio
 branch = true
+data_file = coverage/coverage
 omit = */_version.py
 parallel = true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ pytest11 =
 [coverage:run]
 source = pytest_asyncio
 branch = true
+omit = */_version.py
 
 [coverage:report]
 show_missing = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ pytest11 =
 source = pytest_asyncio
 branch = true
 omit = */_version.py
+parallel = true
 
 [coverage:report]
 show_missing = true


### PR DESCRIPTION
Coverage writes reports to ".coverage" by default. The GitHub action "upload-artifact" no longer includes hidden files by default. This patch changes the coverage file name to a non-hidden file path.

This fixes the failing CI pipeline for pull requests.