### PR TITLE
warn if asyncio test requests async pytest fixture in strict mode

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+0.25.0 (UNRELEASED)
+===================
+- Deprecated: Added warning when asyncio test requests async ``@pytest.fixture`` in strict mode. This will become an error in a future version of flake8-asyncio. `#979 <https://github.com/pytest-dev/pytest-asyncio/pull/979>`_
+
 0.24.0 (2024-08-22)
 ===================
 - BREAKING: Updated minimum supported pytest version to v8.2.0


### PR DESCRIPTION
partially fixes https://github.com/pytest-dev/pytest/issues/10839, see https://github.com/pytest-dev/pytest/issues/10839#issuecomment-2355427134

It got a bit messy to implement, and relies on non-public API in `_fixtureinfo`, so I'm not 100% that this is the best way to approach it. Another approach would be to try and catch this on collection, but then you end up having to handle overriding fixtures and the like.

It's also *possible* that this breaks tests for end users, but if they really do want an unawaited object from a fixture they can resolve it in various ways by returning an `Awaitable` from their fixture.