### PR TITLE
display full param name asyncio_default_fixture_loop_scope

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 ===================
 - Deprecated: Added warning when asyncio test requests async ``@pytest.fixture`` in strict mode. This will become an error in a future version of flake8-asyncio. `#979 <https://github.com/pytest-dev/pytest-asyncio/pull/979>`_
 - Updates the error message about `pytest.mark.asyncio`'s `scope` keyword argument to say `loop_scope` instead. `#1004 <https://github.com/pytest-dev/pytest-asyncio/pull/1004>`_
+- Verbose log displays correct parameter name: asyncio_default_fixture_loop_scope `#990 <https://github.com/pytest-dev/pytest-asyncio/pull/990>`_
 
 0.24.0 (2024-08-22)
 ===================

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -216,7 +216,9 @@ def pytest_report_header(config: Config) -> list[str]:
     """Add asyncio config to pytest header."""
     mode = _get_asyncio_mode(config)
     default_loop_scope = config.getini("asyncio_default_fixture_loop_scope")
-    return [f"asyncio: mode={mode}, default_loop_scope={default_loop_scope}"]
+    return [
+        f"asyncio: mode={mode}, asyncio_default_fixture_loop_scope={default_loop_scope}"
+    ]
 
 
 def _preprocess_async_fixtures(


### PR DESCRIPTION
confirmed verbose output displays correct name:

asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=function

file __version__ not present and I don't understand the issue described in setup.cfg

guessed version in changelog.rst with totally random date (my birthday)