### PR TITLE
Rename 'scope' to 'loop_scope' in error message

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 0.25.0 (UNRELEASED)
 ===================
 - Deprecated: Added warning when asyncio test requests async ``@pytest.fixture`` in strict mode. This will become an error in a future version of flake8-asyncio. `#979 <https://github.com/pytest-dev/pytest-asyncio/pull/979>`_
+- Updates the error message about `pytest.mark.asyncio`'s `scope` keyword argument to say `loop_scope` instead. `#1004 <https://github.com/pytest-dev/pytest-asyncio/pull/1004>`_
 
 0.24.0 (2024-08-22)
 ===================

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -1004,7 +1004,7 @@ def _get_marked_loop_scope(asyncio_marker: Mark) -> _ScopeName:
     if asyncio_marker.args or (
         asyncio_marker.kwargs and set(asyncio_marker.kwargs) - {"loop_scope", "scope"}
     ):
-        raise ValueError("mark.asyncio accepts only a keyword argument 'scope'.")
+        raise ValueError("mark.asyncio accepts only a keyword argument 'loop_scope'.")
     if "scope" in asyncio_marker.kwargs:
         if "loop_scope" in asyncio_marker.kwargs:
             raise pytest.UsageError(_DUPLICATE_LOOP_SCOPE_DEFINITION_ERROR)

--- a/tests/markers/test_invalid_arguments.py
+++ b/tests/markers/test_invalid_arguments.py
@@ -62,7 +62,7 @@ def test_error_when_wrong_keyword_argument_is_passed(
     result = pytester.runpytest_subprocess()
     result.assert_outcomes(errors=1)
     result.stdout.fnmatch_lines(
-        ["*ValueError: mark.asyncio accepts only a keyword argument 'scope'*"]
+        ["*ValueError: mark.asyncio accepts only a keyword argument 'loop_scope'*"]
     )
 
 


### PR DESCRIPTION
Ensures that when a wrong argument is passed, the non-deprecated `loop_scope` keyword arg is recommended.