### PR TITLE
Maintain contextvars between fixtures and tests

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 - Deprecated: Added warning when asyncio test requests async ``@pytest.fixture`` in strict mode. This will become an error in a future version of flake8-asyncio. `#979 <https://github.com/pytest-dev/pytest-asyncio/pull/979>`_
 - Updates the error message about `pytest.mark.asyncio`'s `scope` keyword argument to say `loop_scope` instead. `#1004 <https://github.com/pytest-dev/pytest-asyncio/pull/1004>`_
 - Verbose log displays correct parameter name: asyncio_default_fixture_loop_scope `#990 <https://github.com/pytest-dev/pytest-asyncio/pull/990>`_
+- Propagates `contextvars` set in async fixtures to other fixtures and tests on Python 3.11 and above. `#1008 <https://github.com/pytest-dev/pytest-asyncio/pull/1008>`_
+
 
 0.24.0 (2024-08-22)
 ===================

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -381,12 +381,10 @@ def _create_task_in_context(loop, coro, context):
     the API added for https://github.com/python/cpython/issues/91150.
     On earlier versions, the returned task will use the default context instead.
     """
-    if context is not None:
-        try:
-            return loop.create_task(coro, context=context)
-        except TypeError:
-            pass
-    return loop.create_task(coro)
+    try:
+        return loop.create_task(coro, context=context)
+    except TypeError:
+        return loop.create_task(coro)
 
 
 def _wrap_async_fixture(fixturedef: FixtureDef) -> None:

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -14,6 +14,7 @@ from asyncio import AbstractEventLoopPolicy
 from collections.abc import (
     AsyncIterator,
     Awaitable,
+    Coroutine as AbstractCoroutine,
     Generator,
     Iterable,
     Iterator,
@@ -410,7 +411,11 @@ def _get_event_loop_fixture_id_for_async_fixture(
     return event_loop_fixture_id
 
 
-def _create_task_in_context(loop, coro, context):
+def _create_task_in_context(
+    loop: asyncio.AbstractEventLoop,
+    coro: AbstractCoroutine[Any, Any, _T],
+    context: contextvars.Context,
+) -> asyncio.Task[_T]:
     """
     Return an asyncio task that runs the coro in the specified context,
     if possible.

--- a/tests/async_fixtures/test_async_fixtures_contextvars.py
+++ b/tests/async_fixtures/test_async_fixtures_contextvars.py
@@ -33,21 +33,28 @@ async def no_var_fixture():
 
 
 @pytest.fixture(scope="function")
-async def var_fixture(no_var_fixture):
-    with context_var_manager("value"):
+async def var_fixture_1(no_var_fixture):
+    with context_var_manager("value1"):
         yield
 
 
 @pytest.fixture(scope="function")
-async def var_nop_fixture(var_fixture):
+async def var_nop_fixture(var_fixture_1):
     with context_var_manager(_context_var.get()):
         yield
 
 
 @pytest.fixture(scope="function")
-def inner_var_fixture(var_nop_fixture):
-    assert _context_var.get() == "value"
+def var_fixture_2(var_nop_fixture):
+    assert _context_var.get() == "value1"
     with context_var_manager("value2"):
+        yield
+
+
+@pytest.fixture(scope="function")
+async def var_fixture_3(var_fixture_2):
+    assert _context_var.get() == "value2"
+    with context_var_manager("value3"):
         yield
 
 
@@ -55,5 +62,5 @@ def inner_var_fixture(var_nop_fixture):
 @pytest.mark.xfail(
     sys.version_info < (3, 11), reason="requires asyncio Task context support"
 )
-async def test(inner_var_fixture):
-    assert _context_var.get() == "value2"
+async def test(var_fixture_3):
+    assert _context_var.get() == "value3"

--- a/tests/async_fixtures/test_async_fixtures_contextvars.py
+++ b/tests/async_fixtures/test_async_fixtures_contextvars.py
@@ -1,0 +1,36 @@
+"""
+Regression test for https://github.com/pytest-dev/pytest-asyncio/issues/127:
+contextvars were not properly maintained among fixtures and tests.
+"""
+
+from __future__ import annotations
+
+import sys
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+
+import pytest
+
+
+@asynccontextmanager
+async def context_var_manager():
+    context_var = ContextVar("context_var")
+    token = context_var.set("value")
+    try:
+        yield context_var
+    finally:
+        context_var.reset(token)
+
+
+@pytest.fixture(scope="function")
+async def context_var():
+    async with context_var_manager() as v:
+        yield v
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    sys.version_info < (3, 11), reason="requires asyncio Task context support"
+)
+async def test(context_var):
+    assert context_var.get() == "value"

--- a/tests/async_fixtures/test_async_fixtures_contextvars.py
+++ b/tests/async_fixtures/test_async_fixtures_contextvars.py
@@ -58,9 +58,16 @@ async def var_fixture_3(var_fixture_2):
         yield
 
 
+@pytest.fixture(scope="function")
+async def var_fixture_4(var_fixture_3, request):
+    assert _context_var.get() == "value3"
+    _context_var.set("value4")
+    # Rely on fixture teardown to reset the context var.
+
+
 @pytest.mark.asyncio
 @pytest.mark.xfail(
     sys.version_info < (3, 11), reason="requires asyncio Task context support"
 )
-async def test(var_fixture_3):
-    assert _context_var.get() == "value3"
+async def test(var_fixture_4):
+    assert _context_var.get() == "value4"

--- a/tests/async_fixtures/test_async_fixtures_contextvars.py
+++ b/tests/async_fixtures/test_async_fixtures_contextvars.py
@@ -6,31 +6,54 @@ contextvars were not properly maintained among fixtures and tests.
 from __future__ import annotations
 
 import sys
-from contextlib import asynccontextmanager
+from contextlib import contextmanager
 from contextvars import ContextVar
 
 import pytest
 
+_context_var = ContextVar("context_var")
 
-@asynccontextmanager
-async def context_var_manager():
-    context_var = ContextVar("context_var")
-    token = context_var.set("value")
+
+@contextmanager
+def context_var_manager(value):
+    token = _context_var.set(value)
     try:
-        yield context_var
+        yield
     finally:
-        context_var.reset(token)
+        _context_var.reset(token)
 
 
 @pytest.fixture(scope="function")
-async def context_var():
-    async with context_var_manager() as v:
-        yield v
+async def no_var_fixture():
+    with pytest.raises(LookupError):
+        _context_var.get()
+    yield
+    with pytest.raises(LookupError):
+        _context_var.get()
+
+
+@pytest.fixture(scope="function")
+async def var_fixture(no_var_fixture):
+    with context_var_manager("value"):
+        yield
+
+
+@pytest.fixture(scope="function")
+async def var_nop_fixture(var_fixture):
+    with context_var_manager(_context_var.get()):
+        yield
+
+
+@pytest.fixture(scope="function")
+def inner_var_fixture(var_nop_fixture):
+    assert _context_var.get() == "value"
+    with context_var_manager("value2"):
+        yield
 
 
 @pytest.mark.asyncio
 @pytest.mark.xfail(
     sys.version_info < (3, 11), reason="requires asyncio Task context support"
 )
-async def test(context_var):
-    assert context_var.get() == "value"
+async def test(inner_var_fixture):
+    assert _context_var.get() == "value2"


### PR DESCRIPTION
The approach I've taken here is to inspect the context after running the fixture setup task and copy any changed values out into the test's ambient context. When we run the finalizer to tear down the fixture, we then reset the modified variables.

Some limitations:
- This requires Python 3.11 or higher (for https://github.com/python/cpython/issues/91150).
- Because we have to iterate over the fixture context to copy out changes, this approach may be slow for fixtures that run in contexts with a large number of variables.

Fixes pytest-dev/pytest-asyncio#127.