### PR TITLE
Mention `asyncio_default_fixture_loop_scope` in v0.24 changelog

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 - Updates the error message about `pytest.mark.asyncio`'s `scope` keyword argument to say `loop_scope` instead. `#1004 <https://github.com/pytest-dev/pytest-asyncio/pull/1004>`_
 - Verbose log displays correct parameter name: asyncio_default_fixture_loop_scope `#990 <https://github.com/pytest-dev/pytest-asyncio/pull/990>`_
 
+
 0.24.0 (2024-08-22)
 ===================
 - BREAKING: Updated minimum supported pytest version to v8.2.0
@@ -15,6 +16,7 @@ Changelog
 - Deprecates the optional `scope` keyword argument to `pytest.mark.asyncio` for API consistency with ``pytest_asyncio.fixture``. Users are encouraged to use the `loop_scope` keyword argument, which does exactly the same.
 - Raises an error when passing `scope` or `loop_scope` as a positional argument to ``@pytest.mark.asyncio``. `#812 <https://github.com/pytest-dev/pytest-asyncio/issues/812>`_
 - Fixes a bug that caused module-scoped async fixtures to fail when reused in other modules `#862 <https://github.com/pytest-dev/pytest-asyncio/issues/862>`_ `#668 <https://github.com/pytest-dev/pytest-asyncio/issues/668>`_
+- Added the ``asyncio_default_fixture_loop_scope`` configuration option `c74d1c3 <https://github.com/pytest-dev/pytest-asyncio/commit/c74d1c3fba1afac0b8316763257c915bfba5f5e3>`_
 
 
 0.23.8 (2024-07-17)


### PR DESCRIPTION
This config option is arguably a new API surface, and it took me a fair bit of git archaeology to figure out from which version on I can use this config option.

This entry might save some users some time in the future :)