### PR TITLE
Fix wrong event loop reference with mixed scoped tests

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+0.25.1 (UNRELEASED)
+===================
+- Fixes an issue that caused a broken event loop when a function-scoped test was executed in between two tests with wider loop scope `#950 <https://github.com/pytest-dev/pytest-asyncio/issues/950>`_
+
+
 0.25.0 (2024-12-13)
 ===================
 - Deprecated: Added warning when asyncio test requests async ``@pytest.fixture`` in strict mode. This will become an error in a future version of flake8-asyncio. `#979 <https://github.com/pytest-dev/pytest-asyncio/pull/979>`_

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -861,7 +861,7 @@ def pytest_fixture_setup(
         # Weird behavior was observed when checking for an attribute of FixtureDef.func
         # Instead, we now check for a special attribute of the returned event loop
         fixture_filename = inspect.getsourcefile(fixturedef.func)
-        if not getattr(loop, "__original_fixture_loop", False):
+        if not _is_pytest_asyncio_loop(loop):
             _, fixture_line_number = inspect.getsourcelines(fixturedef.func)
             warnings.warn(
                 _REDEFINED_EVENT_LOOP_FIXTURE_WARNING
@@ -1154,7 +1154,7 @@ def event_loop(request: FixtureRequest) -> Iterator[asyncio.AbstractEventLoop]:
         # set this value.
         # The magic value must be set as part of the function definition, because pytest
         # seems to have multiple instances of the same FixtureDef or fixture function
-        loop.__original_fixture_loop = True  # type: ignore[attr-defined]
+        loop = _make_pytest_asyncio_loop(loop)
         yield loop
         loop.close()
 

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -709,8 +709,7 @@ def pytest_collectstart(collector: pytest.Collector) -> None:
     ) -> Iterator[asyncio.AbstractEventLoop]:
         new_loop_policy = event_loop_policy
         with _temporary_event_loop_policy(new_loop_policy):
-            loop = asyncio.new_event_loop()
-            loop.__pytest_asyncio = True  # type: ignore[attr-defined]
+            loop = _make_pytest_asyncio_loop(asyncio.new_event_loop())
             asyncio.set_event_loop(loop)
             yield loop
             loop.close()
@@ -883,6 +882,11 @@ def pytest_fixture_setup(
         return
 
     yield
+
+
+def _make_pytest_asyncio_loop(loop: AbstractEventLoop) -> AbstractEventLoop:
+    loop.__pytest_asyncio = True  # type: ignore[attr-defined]
+    return loop
 
 
 def _is_pytest_asyncio_loop(loop: AbstractEventLoop) -> bool:
@@ -1161,8 +1165,7 @@ def _session_event_loop(
 ) -> Iterator[asyncio.AbstractEventLoop]:
     new_loop_policy = event_loop_policy
     with _temporary_event_loop_policy(new_loop_policy):
-        loop = asyncio.new_event_loop()
-        loop.__pytest_asyncio = True  # type: ignore[attr-defined]
+        loop = _make_pytest_asyncio_loop(asyncio.new_event_loop())
         asyncio.set_event_loop(loop)
         yield loop
         loop.close()

--- a/tests/markers/test_mixed_scope.py
+++ b/tests/markers/test_mixed_scope.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from textwrap import dedent
+
+from pytest import Pytester
+
+
+def test_function_scoped_loop_restores_previous_loop_scope(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(
+        dedent(
+            """\
+            import asyncio
+            import pytest
+
+
+            module_loop: asyncio.AbstractEventLoop
+
+            @pytest.mark.asyncio(loop_scope="module")
+            async def test_remember_loop():
+                global module_loop
+                module_loop = asyncio.get_running_loop()
+
+            @pytest.mark.asyncio(loop_scope="function")
+            async def test_with_function_scoped_loop():
+                pass
+
+            @pytest.mark.asyncio(loop_scope="module")
+            async def test_runs_in_same_loop():
+                global module_loop
+                assert asyncio.get_running_loop() is module_loop
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=3)

--- a/tests/test_event_loop_fixture_finalizer.py
+++ b/tests/test_event_loop_fixture_finalizer.py
@@ -14,7 +14,8 @@ def test_event_loop_fixture_finalizer_returns_fresh_loop_after_test(pytester: Py
 
             import pytest
 
-            loop = asyncio.get_event_loop_policy().get_event_loop()
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
 
             @pytest.mark.asyncio
             async def test_1():


### PR DESCRIPTION
Issue #950 describes a problem with tests that have mixed event loop scopes. When a function-scoped loop is executed in between two tests with wider loop scope, the tests after the function-scoped tests reference the wrong event loop.

This is caused by the implementation of the _event_loop_ fixture and its finalizers. This PR addresses the issue twofold:
1. It changes the implementation of the _event_loop_ fixture so that it properly restores the current event loop policy and event loop when the fixture is torn down.
2. It changes the _event_loop_ fixture finalizers to only close loops that were not created by pytest-asyncio. This prevents the finalizers from accidentally closing a module-scoped loop provided by the plugin, for example.

Fixes #950 