### PR TITLE
docs: specify how asyncio's mode can be set

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -47,8 +47,12 @@ Assigning neighboring tests to different event loop scopes is discouraged as it 
 Test discovery modes
 ====================
 
-Pytest-asyncio provides two modes for test discovery, *strict* and *auto*.
+Pytest-asyncio provides two modes for test discovery, *strict* and *auto*. This can be set through Pytest's ``--asyncio-mode`` command line flag, or through the configuration file:
 
+.. code-block:: toml
+
+    [tool.pytest.ini_options]
+    asyncio_mode = "auto" # or "strict"
 
 Strict mode
 -----------


### PR DESCRIPTION
When reading the docs, it wasn't clear to me how to set asyncio's mode and I had to rely on looking at the source code. I thought it would be nice to expand the docs to be more explicit in this regard.