### PR TITLE
Fix FixtureFunction TypeAlias and TypeVars

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 0.26.0 (UNRELEASED)
 ===================
 - Adds configuration option that sets default event loop scope for all testss `#793 <https://github.com/pytest-dev/pytest-asyncio/issues/793>`_
+- Improved type annotations for ``pytest_asyncio.fixture`` `#1045 <https://github.com/pytest-dev/pytest-asyncio/pull/1045>`_
+- Added ``typing-extensions`` as additional dependency for Python ``<3.10`` `#1045 <https://github.com/pytest-dev/pytest-asyncio/pull/1045>`_
 
 
 0.25.2 (2025-01-08)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dynamic = [
 
 dependencies = [
   "pytest>=8.2,<9",
+  "typing-extensions>=4.12; python_version<'3.10'",
 ]
 optional-dependencies.docs = [
   "sphinx>=5.3",

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -683,9 +683,7 @@ _fixture_scope_by_collector_type: Mapping[type[pytest.Collector], _ScopeName] = 
 
 # A stack used to push package-scoped loops during collection of a package
 # and pop those loops during collection of a Module
-__package_loop_stack: list[
-    FixtureFunctionMarker[FixtureFunctionType] | FixtureFunctionType
-] = []
+__package_loop_stack: list[Callable[..., Any]] = []
 
 
 @pytest.hookimpl


### PR DESCRIPTION
If TypeVars are used in TypeAliases, they need to be passed along as well. Otherwise it's just interpreted as `Any` similar to all other generic type without subscripts.

This PR reworks the TypeAliases and TypeVars to properly type the `fixture` function.