### PR TITLE
Update project metadata to use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools>=77,<78",
+  "setuptools>=77",
   "setuptools-scm[toml]>=6.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,8 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-
 requires = [
-  "setuptools>=51",
+  "setuptools>=77",
   "setuptools-scm[toml]>=6.2",
-  "wheel>=0.36",
 ]
 
 [project]
@@ -12,7 +10,10 @@ name = "pytest-asyncio"
 description = "Pytest support for asyncio"
 readme.content-type = "text/x-rst"
 readme.file = "README.rst"
-license.text = "Apache 2.0"
+license = "Apache-2.0"
+license-files = [
+  "LICENSE",
+]
 authors = [
   { name = "Tin Tvrtković <tinchester@gmail.com>", email = "tinchester@gmail.com" },
 ]
@@ -22,7 +23,6 @@ classifiers = [
   "Framework :: AsyncIO",
   "Framework :: Pytest",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -60,9 +60,6 @@ packages = [
   "pytest_asyncio",
 ]
 include-package-data = true
-license-files = [
-  "LICENSE",
-]
 
 [tool.setuptools_scm]
 write_to = "pytest_asyncio/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools>=77",
+  "setuptools>=77,<78",
   "setuptools-scm[toml]>=6.2",
 ]
 


### PR DESCRIPTION
[PEP 639](https://peps.python.org/pep-0639/) added support for SPDX license identifier.
Metadata diff
```diff
 ...
-License: Apache 2.0
+License-Expression: Apache-2.0
 ...
-Classifier: License :: OSI Approved :: Apache Software License
 ...
```