### PR TITLE
Use Towncrier to Manage Changelog

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,15 +128,27 @@ jobs:
 
   prepare-release-notes:
     name: Prepare Release Notes
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    needs: [lint]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Install Python
+      uses: actions/setup-python@v5
+    - name: Install towncrier
+      run: pip install towncrier==24.8.0
     - name: Install pandoc
       run: |
         sudo apt-get install -y pandoc
+    - name: Install pytest-asyncio
+      run: pip install .
+    - name: Compile Release Notes Draft
+      if: ${{ !contains(github.ref, 'refs/tags/') }}
+      run: towncrier build --draft --version "${{ needs.lint.outputs.version }}" > release-notes.rst
     - name: Extract release notes from Git tag
+      if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
       run: |
         set -e
         git for-each-ref github.ref --format='%(contents)' > release-notes.rst

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,9 +147,15 @@ jobs:
     - name: Collected dists
       run: |
         tree dist
-    - name: Convert README.rst to Markdown
+    - name: Extract release notes from Git tag
       run: |
-        pandoc -s -o README.md README.rst
+        set -e
+        git for-each-ref github.ref --format='%(contents)' > release-notes.rst
+        # Strip PGP signature from signed tags
+        sed -i "/-----BEGIN PGP SIGNATURE-----/,/-----END PGP SIGNATURE-----\n/d" release-notes.rst
+    - name: Convert Release Notes to Markdown
+      run: |
+        pandoc -s -o release-notes.md release-notes.rst
     - name: PyPI upload
       uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
@@ -161,6 +167,6 @@ jobs:
       with:
         name: pytest-asyncio ${{ needs.lint.outputs.version }}
         artifacts: dist/*
-        bodyFile: README.md
+        bodyFile: release-notes.md
         prerelease: ${{ needs.lint.outputs.prerelease }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,27 +126,16 @@ jobs:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
 
-  deploy:
-    name: Deploy
-    environment: release
-        # Run only on pushing a tag
+  prepare-release-notes:
+    name: Prepare Release Notes
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    needs: [lint, check]
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
     - name: Install pandoc
       run: |
         sudo apt-get install -y pandoc
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Download distributions
-      uses: actions/download-artifact@v4
-      with:
-        name: dist
-        path: dist
-    - name: Collected dists
-      run: |
-        tree dist
     - name: Extract release notes from Git tag
       run: |
         set -e
@@ -156,12 +145,39 @@ jobs:
     - name: Convert Release Notes to Markdown
       run: |
         pandoc -s -o release-notes.md release-notes.rst
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-notes.md
+        path: release-notes.md
+
+  deploy:
+    name: Deploy
+    environment: release
+        # Run only on pushing a tag
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    needs: [lint, check, prepare-release-notes]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download distributions
+      uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist
+    - name: Collected dists
+      run: |
+        tree dist
     - name: PyPI upload
       uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         attestations: true
         packages-dir: dist
         password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Download Release Notes
+      uses: actions/download-artifact@v4
+      with:
+        name: release-notes.md
+        path: release-notes.md
     - name: GitHub Release
       uses: ncipollo/release-action@v1
       with:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This project uses [*towncrier*](https://towncrier.readthedocs.io/) for changlog management and the changes for the upcoming release can be found in <https://github.com/pytest-dev/pytest-asyncio/tree/main/changelog.d/>.
+
+.. towncrier release notes start
+
 0.26.0 (2025-03-25)
 ===================
 - Adds configuration option that sets default event loop scope for all tests `#793 <https://github.com/pytest-dev/pytest-asyncio/issues/793>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,3 +137,44 @@ parallel = true
 
 [tool.coverage.report]
 show_missing = true
+
+[tool.towncrier]
+directory = "changelog.d"
+filename = "docs/reference/changelog.rst"
+title_format = "`{version} <https://github.com/pytest-dev/pytest-asyncio/tree/{version}>`_ - {project_date}"
+issue_format = "`#{issue} <https://github.com/pytest-dev/pytest-asyncio/issues/{issue}>`_"
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "downstream"
+name = "Notes for Downstream Packagers"
+showcontent = true


### PR DESCRIPTION
## Changelog management
The changelog has previously been maintained manually. This lead to avoidable merge conflicts, because of changelog patches. Moreover, it increases the roundtrip time for contributions, because contributors generally don't adjust the changelog which forces the maintainers to ask for an explicit changelog entry.

This patch uses towncrier to collect changelog entries and compile them during the release process.
TBD: Enforce changelog entries

## Release notes
Previously, the release workflow attached the README as release notes. This is mostly unhelpful and results in length email notifications when a pytest-asyncio release is published.

This patch uses the annotation built Git tag as release notes. If the current build is not a Git tag, the compiled towncrier news fragments are published as release notes.

Closes #511 