### PR TITLE
Reduce scoped fixture count

### DIFF
--- a/changelog.d/+d874f4f1.changed.rst
+++ b/changelog.d/+d874f4f1.changed.rst
@@ -1,0 +1,1 @@
+Scoped event loops (e.g. module-scoped loops) are created once rather than per scope (e.g. per module). This reduces the number of fixtures and speeds up collection time, especially for large test suites.


### PR DESCRIPTION
This PR changes the logic for creating fixtures for scoped event loops. Scoped loop fixtures are created once for each scope rather than for each occurence of a scope (e.g. for each module).

This reduces the total number of fixtures and reduces test collection time as a result. The changes are most notable in large test suites.