### PR TITLE
Harden GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,7 +158,9 @@ jobs:
       run: pip install .
     - name: Compile Release Notes Draft
       if: ${{ !contains(github.ref, 'refs/tags/') }}
-      run: towncrier build --draft --version "${{ needs.lint.outputs.version }}" > release-notes.rst
+      run: towncrier build --draft --version "${version}" > release-notes.rst
+      env:
+        version: ${{ needs.lint.outputs.version }}
     - name: Extract release notes from Git tag
       if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,7 +194,7 @@ jobs:
       run: |
         tree dist
     - name: PyPI upload
-      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4  # zizmor: ignore[use-trusted-publishing] # see #700
       with:
         attestations: true
         packages-dir: dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
       with:
         jobs: ${{ toJSON(needs) }}
     - uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
         coverage combine
         coverage xml
     - name: Upload coverage report
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
       with:
         files: coverage.xml
         fail_ci_if_error: true
@@ -184,7 +184,7 @@ jobs:
       run: |
         tree dist
     - name: PyPI upload
-      uses: pypa/gh-action-pypi-publish@v1.12.4
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
       with:
         attestations: true
         packages-dir: dist
@@ -195,7 +195,7 @@ jobs:
         name: release-notes.md
         path: release-notes.md
     - name: GitHub Release
-      uses: ncipollo/release-action@v1
+      uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174  # v1.16.0
       with:
         name: pytest-asyncio ${{ needs.lint.outputs.version }}
         artifacts: dist/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions: {}
+
 env:
   PYTHON_LATEST: 3.13
 
@@ -180,6 +182,8 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     needs: [lint, check, prepare-release-notes]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - name: Download distributions
       uses: actions/download-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_LATEST }}
@@ -75,6 +76,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
@@ -106,6 +109,8 @@ jobs:
       with:
         jobs: ${{ toJSON(needs) }}
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_LATEST }}
@@ -139,6 +144,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Install Python
       uses: actions/setup-python@v5
     - name: Install towncrier

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,10 +100,16 @@ jobs:
         path: coverage/coverage.*
         if-no-files-found: error
 
+  lint-github-actions:
+    name: Lint GitHub Actions
+    permissions:
+      security-events: write
+    uses: zizmorcore/workflow/.github/workflows/reusable-zizmor.yml@1ae473d8672fe7613e809d86d202a35063736e16
+
   check:
     name: Check
     if: always()
-    needs: [lint, test]
+    needs: [lint, lint-github-actions, test]
     runs-on: ubuntu-latest
     steps:
     - name: Decide whether the needed jobs succeeded or failed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,10 @@ repos:
   - id: pyproject-fmt
       # https://pyproject-fmt.readthedocs.io/en/latest/#calculating-max-supported-python-version
     additional_dependencies: [tox>=4.9]
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: v1.7.0
+  hooks:
+  - id: zizmor
 ci:
   skip:
   - actionlint-docker


### PR DESCRIPTION
This PR introduces [zizmor](https://docs.zizmor.sh/) for linting GitHub Actions Workflows and addresses all of its findings.

Zizmor is used both as a pre-commit hook and a separate job in the pipeline. This is due to the fact that some analyses require a GitHub token, which not all developers may have readily available.
