### PR TITLE
Replace event loops with asyncio.Runner

### DIFF
--- a/changelog.d/+127.added.rst
+++ b/changelog.d/+127.added.rst
@@ -1,0 +1,1 @@
+Propagation of ContextVars from async fixtures to other fixtures and tests on Python 3.10 and older

--- a/changelog.d/+6aa3d3e0.added.rst
+++ b/changelog.d/+6aa3d3e0.added.rst
@@ -1,0 +1,1 @@
+Warning when the current event loop is closed by a test

--- a/changelog.d/+6fe51a75.downstream.rst
+++ b/changelog.d/+6fe51a75.downstream.rst
@@ -1,0 +1,1 @@
+Added runtime dependency on `backports.asyncio.runner <https://pypi.org/project/backports.asyncio.runner/>`__ for use with Python 3.10 and older

--- a/changelog.d/+878.fixed.rst
+++ b/changelog.d/+878.fixed.rst
@@ -1,0 +1,1 @@
+Error about missing loop when calling functions requiring a loop in the `finally` clause of a task

--- a/changelog.d/200.added.rst
+++ b/changelog.d/200.added.rst
@@ -1,0 +1,1 @@
+Cancellation of tasks when the `loop_scope` ends

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dynamic = [
 ]
 
 dependencies = [
+  "backports-asyncio-runner>=1.1,<2; python_version<'3.11'",
   "pytest>=8.2,<9",
   "typing-extensions>=4.12; python_version<'3.10'",
 ]

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -818,7 +818,6 @@ def _create_scoped_runner_fixture(scope: _ScopeName) -> Callable:
         name=f"_{scope}_scoped_runner",
     )
     def _scoped_runner(
-        *args,  # Function needs to accept "cls" when collected by pytest.Class
         event_loop_policy,
     ) -> Iterator[Runner]:
         new_loop_policy = event_loop_policy

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -874,23 +874,6 @@ for scope in Scope:
     )
 
 
-@contextlib.contextmanager
-def _provide_event_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    policy = _get_event_loop_policy()
-    loop = policy.new_event_loop()
-    try:
-        yield loop
-    finally:
-        # cleanup the event loop if it hasn't been cleaned up already
-        if not loop.is_closed():
-            try:
-                loop.run_until_complete(loop.shutdown_asyncgens())
-            except Exception as e:
-                warnings.warn(f"Error cleaning up asyncio loop: {e}", RuntimeWarning)
-            finally:
-                loop.close()
-
-
 @pytest.fixture(scope="session", autouse=True)
 def event_loop_policy() -> AbstractEventLoopPolicy:
     """Return an instance of the policy used to create asyncio event loops."""

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -16,7 +16,6 @@ from asyncio import AbstractEventLoop, AbstractEventLoopPolicy
 from collections.abc import (
     AsyncIterator,
     Awaitable,
-    Coroutine as AbstractCoroutine,
     Generator,
     Iterable,
     Iterator,
@@ -367,29 +366,6 @@ def _wrap_async_fixture(
         return result
 
     return _async_fixture_wrapper
-
-
-def _create_task_in_context(
-    loop: asyncio.AbstractEventLoop,
-    coro: AbstractCoroutine[Any, Any, _T],
-    context: contextvars.Context,
-) -> asyncio.Task[_T]:
-    """
-    Return an asyncio task that runs the coro in the specified context,
-    if possible.
-
-    This allows fixture setup and teardown to be run as separate asyncio tasks,
-    while still being able to use context-manager idioms to maintain context
-    variables and make those variables visible to test functions.
-
-    This is only fully supported on Python 3.11 and newer, as it requires
-    the API added for https://github.com/python/cpython/issues/91150.
-    On earlier versions, the returned task will use the default context instead.
-    """
-    try:
-        return loop.create_task(coro, context=context)
-    except TypeError:
-        return loop.create_task(coro)
 
 
 def _apply_contextvar_changes(

--- a/tests/async_fixtures/test_async_fixtures_contextvars.py
+++ b/tests/async_fixtures/test_async_fixtures_contextvars.py
@@ -5,10 +5,8 @@ contextvars were not properly maintained among fixtures and tests.
 
 from __future__ import annotations
 
-import sys
 from textwrap import dedent
 
-import pytest
 from pytest import Pytester
 
 _prelude = dedent(
@@ -56,11 +54,6 @@ def test_var_from_sync_generator_propagates_to_async(pytester: Pytester):
     result.assert_outcomes(passed=1)
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 11),
-    reason="requires asyncio Task context support",
-    strict=True,
-)
 def test_var_from_async_generator_propagates_to_sync(pytester: Pytester):
     pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
@@ -86,11 +79,6 @@ def test_var_from_async_generator_propagates_to_sync(pytester: Pytester):
     result.assert_outcomes(passed=1)
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 11),
-    reason="requires asyncio Task context support",
-    strict=True,
-)
 def test_var_from_async_fixture_propagates_to_sync(pytester: Pytester):
     pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
@@ -115,11 +103,6 @@ def test_var_from_async_fixture_propagates_to_sync(pytester: Pytester):
     result.assert_outcomes(passed=1)
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 11),
-    reason="requires asyncio Task context support",
-    strict=True,
-)
 def test_var_from_generator_reset_before_previous_fixture_cleanup(pytester: Pytester):
     pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
@@ -149,11 +132,6 @@ def test_var_from_generator_reset_before_previous_fixture_cleanup(pytester: Pyte
     result.assert_outcomes(passed=1)
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 11),
-    reason="requires asyncio Task context support",
-    strict=True,
-)
 def test_var_from_fixture_reset_before_previous_fixture_cleanup(pytester: Pytester):
     pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
@@ -183,11 +161,6 @@ def test_var_from_fixture_reset_before_previous_fixture_cleanup(pytester: Pytest
     result.assert_outcomes(passed=1)
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 11),
-    reason="requires asyncio Task context support",
-    strict=True,
-)
 def test_var_previous_value_restored_after_fixture(pytester: Pytester):
     pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(
@@ -216,11 +189,6 @@ def test_var_previous_value_restored_after_fixture(pytester: Pytester):
     result.assert_outcomes(passed=1)
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 11),
-    reason="requires asyncio Task context support",
-    strict=True,
-)
 def test_var_set_to_existing_value_ok(pytester: Pytester):
     pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(

--- a/tests/test_task_cleanup.py
+++ b/tests/test_task_cleanup.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from textwrap import dedent
+
+from pytest import Pytester
+
+
+def test_task_is_cancelled_when_abandoned_by_test(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(
+        dedent(
+            """\
+        import asyncio
+        import pytest
+
+        @pytest.mark.asyncio
+        async def test_create_task():
+            async def coroutine():
+                try:
+                    while True:
+                        await asyncio.sleep(0)
+                finally:
+                    raise RuntimeError("The task should be cancelled at this point.")
+
+            asyncio.create_task(coroutine())
+        """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Previously, pytest-asyncio used a combination of low-level asyncio functions to manage event loops. This patch replaces the low-level functions with the use of asyncio.Runner.

The runner takes care of cancelling remaining tasks at the end of its scope, avoiding errors about pending tasks. This also fixes an issue that caused RuntimeErrors in abanoned tasks that called functions which depend on a running loop.
    
Moreover, the use of asyncio.Runner and its backport allows backporting the propagation of contextvars from fixtures to tests to Python 3.9 and Python 3.10.


Supersedes #309
Closes #127 
Closes #200
Closes #878 
Partially addresses #1032 