### PR TITLE
Simplify synchronizers

### DIFF
--- a/changelog.d/+b22c903a.fixed.rst
+++ b/changelog.d/+b22c903a.fixed.rst
@@ -1,0 +1,1 @@
+An error that could cause duplicate warnings to be issued

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -451,11 +451,10 @@ class Coroutine(PytestAsyncioFunction):
         return inspect.iscoroutinefunction(func)
 
     def runtest(self) -> None:
-        self.obj = wrap_in_sync(
-            # https://github.com/pytest-dev/pytest-asyncio/issues/596
-            self.obj,  # type: ignore[has-type]
-        )
-        super().runtest()
+        synchronized_obj = wrap_in_sync(self.obj)
+        with MonkeyPatch.context() as c:
+            c.setattr(self, "obj", synchronized_obj)
+            super().runtest()
 
 
 class AsyncGenerator(PytestAsyncioFunction):
@@ -494,11 +493,10 @@ class AsyncStaticMethod(PytestAsyncioFunction):
         )
 
     def runtest(self) -> None:
-        self.obj = wrap_in_sync(
-            # https://github.com/pytest-dev/pytest-asyncio/issues/596
-            self.obj,  # type: ignore[has-type]
-        )
-        super().runtest()
+        synchronized_obj = wrap_in_sync(self.obj)
+        with MonkeyPatch.context() as c:
+            c.setattr(self, "obj", synchronized_obj)
+            super().runtest()
 
 
 class AsyncHypothesisTest(PytestAsyncioFunction):
@@ -517,10 +515,10 @@ class AsyncHypothesisTest(PytestAsyncioFunction):
         )
 
     def runtest(self) -> None:
-        self.obj.hypothesis.inner_test = wrap_in_sync(
-            self.obj.hypothesis.inner_test,
-        )
-        super().runtest()
+        synchronized_obj = wrap_in_sync(self.obj.hypothesis.inner_test)
+        with MonkeyPatch.context() as c:
+            c.setattr(self.obj.hypothesis, "inner_test", synchronized_obj)
+            super().runtest()
 
 
 # The function name needs to start with "pytest_"

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -247,18 +247,6 @@ def _fixture_synchronizer(
         return fixturedef.func
 
 
-def _add_kwargs(
-    func: Callable[..., Any],
-    kwargs: dict[str, Any],
-    request: FixtureRequest,
-) -> dict[str, Any]:
-    sig = inspect.signature(func)
-    ret = kwargs.copy()
-    if "request" in sig.parameters:
-        ret["request"] = request
-    return ret
-
-
 AsyncGenFixtureParams = ParamSpec("AsyncGenFixtureParams")
 AsyncGenFixtureYieldType = TypeVar("AsyncGenFixtureYieldType")
 

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -689,12 +689,6 @@ def wrap_in_sync(
     Return a sync wrapper around an async function executing it in the
     current event loop.
     """
-    # if the function is already wrapped, we rewrap using the original one
-    # not using __wrapped__ because the original function may already be
-    # a wrapped one
-    raw_func = getattr(func, "_raw_test_func", None)
-    if raw_func is not None:
-        func = raw_func
 
     @functools.wraps(func)
     def inner(*args, **kwargs):
@@ -711,7 +705,6 @@ def wrap_in_sync(
                 task.exception()
             raise
 
-    inner._raw_test_func = func  # type: ignore[attr-defined]
     return inner
 
 

--- a/tests/markers/test_function_scope.py
+++ b/tests/markers/test_function_scope.py
@@ -88,7 +88,7 @@ def test_warns_when_scope_argument_is_present(pytester: Pytester):
         )
     )
     result = pytester.runpytest_subprocess("--asyncio-mode=strict")
-    result.assert_outcomes(passed=1, warnings=2)
+    result.assert_outcomes(passed=1, warnings=1)
     result.stdout.fnmatch_lines("*DeprecationWarning*")
 
 


### PR DESCRIPTION
This is a refactoring patch aiming to simplify the logic of synchronizers in the code. It is best reviewed commit by commit.