### PR TITLE
Make new_event_loop as a non-deprecated approch to running different eventloops

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -546,6 +546,21 @@ def _temporary_event_loop_policy(policy: AbstractEventLoopPolicy) -> Iterator[No
         _set_event_loop(old_loop)
 
 
+@contextlib.contextmanager
+def _temporary_event_loop(loop:AbstractEventLoop):
+    try:
+        old_event_loop = asyncio.get_event_loop()
+    except RuntimeError:
+        old_event_loop = None
+    
+    asyncio.set_event_loop(old_event_loop)
+    try:
+        yield 
+    finally:
+        asyncio.set_event_loop(old_event_loop)
+
+
+
 def _get_event_loop_policy() -> AbstractEventLoopPolicy:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
@@ -772,6 +787,9 @@ def _create_scoped_runner_fixture(scope: _ScopeName) -> Callable:
                             RuntimeWarning,
                         )
 
+    
+
+
     return _scoped_runner
 
 
@@ -779,6 +797,11 @@ for scope in Scope:
     globals()[f"_{scope.value}_scoped_runner"] = _create_scoped_runner_fixture(
         scope.value
     )
+
+@pytest.fixture(scope="session", autouse=True)
+def new_event_loop() -> AbstractEventLoop:
+    """Creates a new eventloop for different tests being ran"""
+    return asyncio.new_event_loop()
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
After mentally thinking about this back and forth. I decided to step to the plate and try and fix this problem once and for all. 
The aiohttp developers have told me they had a bit of intrest utilizing this library and so would I with my plans to migrate from unittest to pytest for [winloop](https://github.com/Vizonex/winloop) and a new project coming that aims to upgrade & migrate [pycares to cython](https://github.com/Vizonex/cyares), which I've added my own deadline that I would move winloop to pytest by 2026. And yes [aiothreading](https://github.com/Vizonex/aiothreading) which aims to be an alternative to aiomultiprocess for users with slower hardware or providing safer solutions for heavier loads.

While talking with the aiohttp devs on the matrix about the problem. I decided to see if I could have a crack at providing a way to run eventloops without needing to use deprecated setups. Unfortunately I'm extremely picky about deprecated setups This might be a good thing however because the sooner someone does something to solve the problem the better.
