### PR TITLE
Add pyright hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,13 @@ repos:
   rev: v1.11.0
   hooks:
   - id: zizmor
+- repo: https://github.com/RobertCraigie/pyright-python
+  rev: v1.1.403
+  hooks:
+  - id: pyright
+    exclude: ^(docs|tests)/.*
+    additional_dependencies:
+    - pytest
 ci:
   skip:
   - actionlint-docker

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,14 +78,6 @@ repos:
   rev: v1.11.0
   hooks:
   - id: zizmor
-- repo: https://github.com/RobertCraigie/pyright-python
-  rev: v1.1.403
-  hooks:
-  - id: pyright
-    exclude: ^(docs|tests)/.*
-    additional_dependencies:
-    - pytest
-    - nodeenv
 ci:
   skip:
   - actionlint-docker

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,6 +85,7 @@ repos:
     exclude: ^(docs|tests)/.*
     additional_dependencies:
     - pytest
+    - nodeenv
 ci:
   skip:
   - actionlint-docker

--- a/changelog.d/731.downstream.rst
+++ b/changelog.d/731.downstream.rst
@@ -1,0 +1,1 @@
+Added pyright type-checking.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -392,6 +392,7 @@ class PytestAsyncioFunction(Function):
         Function item.
         """
         assert function.get_closest_marker("asyncio")
+        assert function.parent is not None
         subclass_instance = cls.from_parent(
             function.parent,
             name=function.name,

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -392,7 +392,6 @@ class PytestAsyncioFunction(Function):
         Function item.
         """
         assert function.get_closest_marker("asyncio")
-        assert function.parent is not None
         subclass_instance = cls.from_parent(
             function.parent,
             name=function.name,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.9.0
-envlist = py39, py310, py311, py312, py313, py314, pytest-min, docs
+envlist = py39, py310, py311, py312, py313, py314, pytest-min, docs, pyright
 isolated_build = true
 passenv =
     CI
@@ -68,6 +68,13 @@ isolated_build = true
 passenv =
     SSH_AUTH_SOCK
 skip_install = false
+
+[testenv:pyright]
+deps =
+    pyright[nodejs]
+    pytest
+commands = pyright pytest_asyncio/
+skip_install = true
 
 [gh-actions]
 python =


### PR DESCRIPTION
Hello, I was working with this plugin and encountered this issue.

I added pyright as a pre-commit check with exclusions matching the mypy hook.

This reveals one error involving `function.parent` possibly being `None`. I resolved this by adding an assertion, as that appears to be most consistent with the rest of the codebase.

The pre-commit hooks and test suite are passing locally.

Closes #731
