### PR TITLE
Fix: Add validation for `asyncio_default_fixture_loop_scope`

### DIFF
--- a/changelog.d/1189.added.rst
+++ b/changelog.d/1189.added.rst
@@ -1,0 +1,1 @@
+A ``pytest.UsageError`` for invalid configuration values of ``asyncio_default_fixture_loop_scope`` and ``asyncio_default_test_loop_scope``.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -234,10 +234,25 @@ avoid unexpected behavior in the future. Valid fixture loop scopes are: \
 """
 
 
+def _validate_scope(scope: str | None, option_name: str) -> None:
+    if scope is None:
+        return
+    valid_scopes = [s.value for s in Scope]
+    if scope not in valid_scopes:
+        raise pytest.UsageError(
+            f"{scope!r} is not a valid {option_name}. "
+            f"Valid scopes are: {', '.join(valid_scopes)}."
+        )
+
+
 def pytest_configure(config: Config) -> None:
-    default_loop_scope = config.getini("asyncio_default_fixture_loop_scope")
-    if not default_loop_scope:
+    default_fixture_loop_scope = config.getini("asyncio_default_fixture_loop_scope")
+    _validate_scope(default_fixture_loop_scope, "asyncio_default_fixture_loop_scope")
+    if not default_fixture_loop_scope:
         warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
+
+    default_test_loop_scope = config.getini("asyncio_default_test_loop_scope")
+    _validate_scope(default_test_loop_scope, "asyncio_default_test_loop_scope")
     config.addinivalue_line(
         "markers",
         "asyncio: "

--- a/tests/test_fixture_loop_scopes.py
+++ b/tests/test_fixture_loop_scopes.py
@@ -136,3 +136,20 @@ def test_default_package_loop_scope_config_option_changes_fixture_loop_scope(
     )
     result = pytester.runpytest_subprocess("--asyncio-mode=strict")
     result.assert_outcomes(passed=1)
+
+
+def test_invalid_default_fixture_loop_scope_raises_error(pytester: Pytester):
+    pytester.makeini(
+        """\
+        [pytest]
+        asyncio_default_fixture_loop_scope = invalid_scope
+        """
+    )
+    result = pytester.runpytest()
+    result.stderr.fnmatch_lines(
+        [
+            "ERROR: 'invalid_scope' is not a valid "
+            "asyncio_default_fixture_loop_scope. Valid scopes are: "
+            "function, class, module, package, session."
+        ]
+    )


### PR DESCRIPTION
This PR addresses an issue where the `asyncio_default_fixture_loop_scope` configuration option in `pytest.ini` was not being validated. This could lead to misconfigurations and unexpected behavior without providing any feedback to the user.

This change introduces a validation check in `pytest_asyncio/plugin.py` to ensure that the provided scope is one of the valid options (`function`, `class`, `module`, `package`, or `session`). If an invalid scope is provided, a `pytest.UsageError` is raised with a descriptive error message.

Additionally, a new test case has been added to `tests/test_fixture_loop_scopes.py` to verify that an invalid scope configuration correctly raises an error.