### PR TITLE
Ensure async fixture setup and teardown run in the same task

### DIFF
--- a/tests/async_fixtures/test_async_fixtures.py
+++ b/tests/async_fixtures/test_async_fixtures.py
@@ -37,3 +37,14 @@ class TestAsyncFixtureMethod:
     @pytest.mark.asyncio
     async def test_async_fixture_method(self):
         assert self.is_same_instance
+
+
+@pytest.fixture()
+async def setup_and_teardown_tasks():
+    task = asyncio.current_task()
+    yield
+    assert task is asyncio.current_task()
+
+
+async def test_setup_and_teardown_tasks(setup_and_teardown_tasks):
+    pass


### PR DESCRIPTION
An attempt to fix https://github.com/pytest-dev/pytest-asyncio/issues/1191.

Inspired by anyio's pytest plugin: https://github.com/agronholm/anyio/blob/b8e91a5cfe35c3b28f91ea8251674a871a7f4e26/src/anyio/_backends/_asyncio.py#L2222-L2239