### PR TITLE
fix typos flake8-asyncio -> pytest-asyncio

### DIFF
--- a/changelog.d/1198.fixed.rst
+++ b/changelog.d/1198.fixed.rst
@@ -1,0 +1,1 @@
+Deprecation warning when decorating an asynchronous fixture with ``@pytest.fixture`` in `strict` mode. The warning message now refers to the correct package.

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -96,7 +96,7 @@ Notes for Downstream Packagers
 
 0.25.0 (2024-12-13)
 ===================
-- Deprecated: Added warning when asyncio test requests async ``@pytest.fixture`` in strict mode. This will become an error in a future version of flake8-asyncio. `#979 <https://github.com/pytest-dev/pytest-asyncio/pull/979>`_
+- Deprecated: Added warning when asyncio test requests async ``@pytest.fixture`` in strict mode. This will become an error in a future version of pytest-asyncio. `#979 <https://github.com/pytest-dev/pytest-asyncio/pull/979>`_
 - Updates the error message about `pytest.mark.asyncio`'s `scope` keyword argument to say `loop_scope` instead. `#1004 <https://github.com/pytest-dev/pytest-asyncio/pull/1004>`_
 - Verbose log displays correct parameter name: asyncio_default_fixture_loop_scope `#990 <https://github.com/pytest-dev/pytest-asyncio/pull/990>`_
 - Propagates `contextvars` set in async fixtures to other fixtures and tests on Python 3.11 and above. `#1008 <https://github.com/pytest-dev/pytest-asyncio/pull/1008>`_

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -630,7 +630,7 @@ def pytest_pyfunc_call(pyfuncitem: Function) -> object | None:
                             "You might want to use @pytest_asyncio.fixture or switch "
                             "to auto mode. "
                             "This will become an error in future versions of "
-                            "flake8-asyncio."
+                            "pytest-asyncio."
                         ),
                         stacklevel=1,
                     )

--- a/tests/modes/test_strict_mode.py
+++ b/tests/modes/test_strict_mode.py
@@ -173,7 +173,7 @@ def test_strict_mode_marked_test_unmarked_fixture_warning(pytester: Pytester):
                 "@pytest.fixture 'any_fixture' in strict mode. "
                 "You might want to use @pytest_asyncio.fixture or switch to "
                 "auto mode. "
-                "This will become an error in future versions of flake8-asyncio."
+                "This will become an error in future versions of pytest-asyncio."
             ),
         ],
     )
@@ -220,7 +220,7 @@ def test_strict_mode_marked_test_unmarked_autouse_fixture_warning(pytester: Pyte
                 "@pytest.fixture 'any_fixture' in strict mode. "
                 "You might want to use @pytest_asyncio.fixture or switch to "
                 "auto mode. "
-                "This will become an error in future versions of flake8-asyncio."
+                "This will become an error in future versions of pytest-asyncio."
             ),
         ],
     )


### PR DESCRIPTION
Was reading through the changelog and found this amusing brain fart I introduced in #979
Turns out I've contributed to way too many flake8-* projects x)