### PR TITLE
Revert pinning of build-time dependencing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools==80.9",
-  "setuptools-scm==9.2",
+  "setuptools>=77",
+  "setuptools-scm[toml]>=6.2",
 ]
 
 [project]


### PR DESCRIPTION
Pinning to specific versions in pyproject.toml makes it very hard for downstream packagers to build pytest-asyncio from source.

see https://github.com/pytest-dev/pytest-asyncio/pull/1192#issuecomment-3194461684