### PR TITLE
Remove use of deprecated function from test synchronizer

### DIFF
--- a/tests/async_fixtures/test_async_fixtures_contextvars.py
+++ b/tests/async_fixtures/test_async_fixtures_contextvars.py
@@ -6,7 +6,9 @@ contextvars were not properly maintained among fixtures and tests.
 from __future__ import annotations
 
 from textwrap import dedent
+from typing import Literal
 
+import pytest
 from pytest import Pytester
 
 _prelude = dedent(
@@ -213,3 +215,56 @@ def test_var_set_to_existing_value_ok(pytester: Pytester):
     )
     result = pytester.runpytest("--asyncio-mode=strict")
     result.assert_outcomes(passed=1)
+
+
+def test_no_isolation_against_context_changes_in_sync_tests(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(
+        dedent(
+            """
+            import pytest
+            import pytest_asyncio
+            from contextvars import ContextVar
+
+            _context_var = ContextVar("my_var")
+
+            def test_sync():
+                _context_var.set("new_value")
+
+            @pytest.mark.asyncio
+            async def test_async():
+                assert _context_var.get() == "new_value"
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=2)
+
+
+@pytest.mark.parametrize("loop_scope", ("function", "module"))
+def test_isolation_against_context_changes_in_async_tests(
+    pytester: Pytester, loop_scope: Literal["function", "module"]
+):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(
+        dedent(
+            f"""
+            import pytest
+            import pytest_asyncio
+            from contextvars import ContextVar
+
+            _context_var = ContextVar("my_var")
+
+            @pytest.mark.asyncio(loop_scope="{loop_scope}")
+            async def test_async_first():
+                _context_var.set("new_value")
+
+            @pytest.mark.asyncio(loop_scope="{loop_scope}")
+            async def test_async_second():
+                with pytest.raises(LookupError):
+                    _context_var.get()
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
The function *wrap_in_sync* makes use of of `_get_event_loop_no_warn` which uses deprecated asyncio functionality.

This PR removes the use of `_get_event_loop_no_warn` inside `wrap_in_sync` by hoisting the decision logic for determining the current event loop one level higher. `PytestAsyncTest` now determines the applicable runner fixture and passes it to *wrap_in_sync*.

Lastly, the PR renames `wrap_in_sync` to `_synchronize_coroutine`.