### PR TITLE
Centralize test setup logic

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -443,10 +443,9 @@ class PytestAsyncioFunction(Function):
         raise NotImplementedError()
 
     def setup(self) -> None:
-        fixturenames = self.fixturenames
         runner_fixture_id = f"_{self._loop_scope}_scoped_runner"
-        if runner_fixture_id not in fixturenames:
-            fixturenames.append(runner_fixture_id)
+        if runner_fixture_id not in self.fixturenames:
+            self.fixturenames.append(runner_fixture_id)
         return super().setup()
 
     def runtest(self) -> None:


### PR DESCRIPTION
This patch moves logic for test setup from a pytest hook to the respective pytest-asyncio test item classes.

Compared to performing the same logic in a pytest hook, this approach centralizes the logic for test execution and makes it easier to follow the program flow. The fact that the setup code executes inside the concrete subclass of *PytestAsyncioFunction* rather than a generic *pytest.Item* leads to fewer safety checks as an added benefit.