### PR TITLE
Add support for pytest 9 and drop Python 3.9 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 3.14t]
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 3.14t]
         required: [true]
 
     steps:

--- a/changelog.d/1278.added.rst
+++ b/changelog.d/1278.added.rst
@@ -1,0 +1,1 @@
+Support for pytest 9

--- a/changelog.d/1278.removed.rst
+++ b/changelog.d/1278.removed.rst
@@ -1,0 +1,1 @@
+Support for Python 3.9

--- a/constraints.txt
+++ b/constraints.txt
@@ -37,7 +37,7 @@ Pygments==2.19.2
 pycparser==2.23
 pydantic==2.11.10
 pydantic-core==2.33.2
-pytest==8.4.2
+pytest==9.0.0
 readme-renderer==44.0
 requests==2.32.5
 requests-toolbelt==1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,13 @@ maintainers = [
 authors = [
   { name = "Tin Tvrtković", email = "tinchester@gmail.com" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: AsyncIO",
   "Framework :: Pytest",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -42,7 +41,7 @@ dynamic = [
 
 dependencies = [
   "backports-asyncio-runner>=1.1,<2; python_version<'3.11'",
-  "pytest>=8.2,<9",
+  "pytest>=8.2,<10",
   "typing-extensions>=4.12; python_version<'3.13'",
 ]
 optional-dependencies.docs = [

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -16,6 +16,7 @@ from asyncio import AbstractEventLoop, AbstractEventLoopPolicy
 from collections.abc import (
     AsyncIterator,
     Awaitable,
+    Callable,
     Generator,
     Iterable,
     Iterator,
@@ -24,10 +25,9 @@ from collections.abc import (
 from types import AsyncGeneratorType, CoroutineType
 from typing import (
     Any,
-    Callable,
     Literal,
+    ParamSpec,
     TypeVar,
-    Union,
     overload,
 )
 
@@ -49,11 +49,6 @@ from pytest import (
     PytestPluginManager,
 )
 
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec
-else:
-    from typing_extensions import ParamSpec
-
 if sys.version_info >= (3, 11):
     from asyncio import Runner
 else:
@@ -65,7 +60,7 @@ else:
     from typing_extensions import TypeIs
 
 _ScopeName = Literal["session", "package", "module", "class", "function"]
-_R = TypeVar("_R", bound=Union[Awaitable[Any], AsyncIterator[Any]])
+_R = TypeVar("_R", bound=Awaitable[Any] | AsyncIterator[Any])
 _P = ParamSpec("_P")
 FixtureFunction = Callable[_P, _R]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.28.0
-envlist = build, py39, py310, py311, py312, py313, py314, pytest-min, docs, pyright
+envlist = build, py310, py311, py312, py313, py314, pytest-min, docs, pyright
 isolated_build = true
 passenv =
     CI
@@ -90,8 +90,7 @@ skip_install = true
 
 [gh-actions]
 python =
-    3.9: py39, pytest-min, build
-    3.10: py310
+    3.10: py310, pytest-min, build
     3.11: py311
     3.12: py312
     3.13: py313, pyright


### PR DESCRIPTION
Pytest 9 dropped support for Python 3.9 so that is why I dropped it here.