### PR TITLE
pre-commit: Placate zizmor by adding dependabot cooldown configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,12 @@ updates:
     interval: weekly
   open-pull-requests-limit: 10
   target-branch: main
+  cooldown:
+    default-days: 7
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
These changes are currently blocking:
* #1293

% `uvx zizmor --fix=safe .`
* https://docs.astral.sh/uv
* https://pypi.org/project/zizmor
* https://docs.zizmor.sh/audits/#dependabot-cooldown

@seifertm 