### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`__, and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
-This project uses `towncrier <https://towncrier.readthedocs.io/>`__ for changlog management and the changes for the upcoming release can be found in https://github.com/pytest-dev/pytest-asyncio/tree/main/changelog.d/.
+This project uses `towncrier <https://towncrier.readthedocs.io/>`__ for changelog management and the changes for the upcoming release can be found in https://github.com/pytest-dev/pytest-asyncio/tree/main/changelog.d/.
 
 .. towncrier release notes start
 

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -488,7 +488,7 @@ class PytestAsyncioFunction(Function):
         """
         Return the coroutine that needs to be synchronized during the test run.
 
-        This method is inteded to be overwritten by subclasses when they need to apply
+        This method is intended to be overwritten by subclasses when they need to apply
         the coroutine synchronizer to a value that's different from self.obj
         e.g. the AsyncHypothesisTest subclass.
         """


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell`
```
./docs/reference/changelog.rst:9: changlog ==> changelog
./pytest_asyncio/plugin.py:491: inteded ==> intended
```
% `codespell --write-changes` 