### PR TITLE
trivial: Formatting in default fixture loop scope message

### DIFF
--- a/changelog.d/1298.changed.rst
+++ b/changelog.d/1298.changed.rst
@@ -1,0 +1,1 @@
+Improved the readability of the warning message that is displayed when ``asyncio_default_fixture_loop_scope`` is unset

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -221,10 +221,10 @@ def _get_asyncio_debug(config: Config) -> bool:
 
 _DEFAULT_FIXTURE_LOOP_SCOPE_UNSET = """\
 The configuration option "asyncio_default_fixture_loop_scope" is unset.
-The event loop scope for asynchronous fixtures will default to the fixture caching \
+The event loop scope for asynchronous fixtures will default to the "fixture" caching \
 scope. Future versions of pytest-asyncio will default the loop scope for asynchronous \
-fixtures to function scope. Set the default fixture loop scope explicitly in order to \
-avoid unexpected behavior in the future. Valid fixture loop scopes are: \
+fixtures to "function" scope. Set the default fixture loop scope explicitly in order \
+to avoid unexpected behavior in the future. Valid fixture loop scopes are: \
 "function", "class", "module", "package", "session"
 """
 


### PR DESCRIPTION
This message is long and a bit difficult to read; a little formatting can make it easier to read.