### PR TITLE
Promote warning to error when applying @pytest.fixture to async fixtures

### DIFF
--- a/changelog.d/1202.breaking.rst
+++ b/changelog.d/1202.breaking.rst
@@ -1,0 +1,1 @@
+**Breaking change**: using ``@pytest.fixture`` on async fixtures in strict mode raises ``pytest.UsageError`` instead of ``PytestDeprecationWarning``

--- a/changelog.d/1202.breaking.rst
+++ b/changelog.d/1202.breaking.rst
@@ -1,1 +1,0 @@
-**Breaking change**: using ``@pytest.fixture`` on async fixtures in strict mode raises ``pytest.UsageError`` instead of ``PytestDeprecationWarning``

--- a/changelog.d/1202.changed.rst
+++ b/changelog.d/1202.changed.rst
@@ -1,0 +1,1 @@
+**Breaking change**: using ``@pytest.fixture`` on async fixtures in strict mode raises ``pytest.UsageError`` instead of ``PytestDeprecationWarning``

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -670,22 +670,13 @@ def pytest_pyfunc_call(pyfuncitem: Function) -> object | None:
                     and _is_coroutine_or_asyncgen(func)
                     and not _is_asyncio_fixture_function(func)
                 ):
-                    warnings.warn(
-                        PytestDeprecationWarning(
-                            f"asyncio test {pyfuncitem.name!r} requested async "
-                            "@pytest.fixture "
-                            f"{fixname!r} in strict mode. "
-                            "You might want to use @pytest_asyncio.fixture or switch "
-                            "to auto mode. "
-                            "This will become an error in future versions of "
-                            "pytest-asyncio."
-                        ),
-                        stacklevel=1,
+                    raise pytest.UsageError(
+                        f"asyncio test {pyfuncitem.name!r} requested async "
+                        "@pytest.fixture "
+                        f"{fixname!r} in strict mode. "
+                        "You might want to use @pytest_asyncio.fixture or switch "
+                        "to auto mode. "
                     )
-                    # no stacklevel points at the users code, so we set stacklevel=1
-                    # so it at least indicates that it's the plugin complaining.
-                    # Pytest gives the test file & name in the warnings summary at least
-
         else:
             pyfuncitem.warn(
                 pytest.PytestWarning(

--- a/tests/modes/test_strict_mode.py
+++ b/tests/modes/test_strict_mode.py
@@ -129,26 +129,23 @@ def test_strict_mode_marked_test_unmarked_fixture_warning(pytester: Pytester):
         """))
     result = pytester.runpytest("--asyncio-mode=strict", "-W default", "--assert=plain")
     if pytest_version >= (8, 4, 0):
-        result.assert_outcomes(passed=1, failed=0, skipped=0, warnings=2)
+        result.assert_outcomes(failed=1, warnings=2)
     else:
-        result.assert_outcomes(passed=1, failed=0, skipped=0, warnings=1)
-    result.stdout.fnmatch_lines(
-        [
-            "*warnings summary*",
+        result.assert_outcomes(failed=1, warnings=1)
+
+        result.stdout.fnmatch_lines([
             (
                 "test_strict_mode_marked_test_unmarked_fixture_warning.py::"
                 "test_anything"
             ),
             (
-                "*/pytest_asyncio/plugin.py:*: PytestDeprecationWarning: "
-                "asyncio test 'test_anything' requested async "
-                "@pytest.fixture 'any_fixture' in strict mode. "
-                "You might want to use @pytest_asyncio.fixture or switch to "
-                "auto mode. "
-                "This will become an error in future versions of pytest-asyncio."
-            ),
-        ],
-    )
+                "*pytest.UsageError*"
+                "*asyncio test 'test_anything' requested async *"
+                "*@pytest.fixture 'any_fixture' in strict mode.*"
+                "*You might want to use @pytest_asyncio.fixture*"
+                "*or switch to auto mode*"
+            )
+        ])
 
 
 # autouse is not handled in any special way currently
@@ -172,23 +169,16 @@ def test_strict_mode_marked_test_unmarked_autouse_fixture_warning(pytester: Pyte
         """))
     result = pytester.runpytest("--asyncio-mode=strict", "-W default", "--assert=plain")
     if pytest_version >= (8, 4, 0):
-        result.assert_outcomes(passed=1, warnings=2)
+        result.assert_outcomes(failed=1, warnings=2)
     else:
-        result.assert_outcomes(passed=1, warnings=1)
-    result.stdout.fnmatch_lines(
-        [
-            "*warnings summary*",
+        result.assert_outcomes(failed=1, warnings=1)
+    result.stdout.fnmatch_lines([
             (
-                "test_strict_mode_marked_test_unmarked_autouse_fixture_warning.py::"
-                "test_anything"
-            ),
-            (
-                "*/pytest_asyncio/plugin.py:*: PytestDeprecationWarning: "
-                "*asyncio test 'test_anything' requested async "
-                "@pytest.fixture 'any_fixture' in strict mode. "
-                "You might want to use @pytest_asyncio.fixture or switch to "
-                "auto mode. "
-                "This will become an error in future versions of pytest-asyncio."
+                "*pytest.UsageError*"
+                "*asyncio test 'test_anything' requested async *"
+                "*@pytest.fixture 'any_fixture' in strict mode. "
+                "*You might want to use @pytest_asyncio.fixture*"
+                "*or switch to auto mode*"
             ),
         ],
     )

--- a/tests/modes/test_strict_mode.py
+++ b/tests/modes/test_strict_mode.py
@@ -133,19 +133,14 @@ def test_strict_mode_marked_test_unmarked_fixture_warning(pytester: Pytester):
     else:
         result.assert_outcomes(failed=1, warnings=1)
 
-        result.stdout.fnmatch_lines([
-            (
-                "test_strict_mode_marked_test_unmarked_fixture_warning.py::"
-                "test_anything"
-            ),
-            (
-                "*pytest.UsageError*"
+        result.stdout.fnmatch_lines(
+            [
                 "*asyncio test 'test_anything' requested async *"
                 "*@pytest.fixture 'any_fixture' in strict mode.*"
                 "*You might want to use @pytest_asyncio.fixture*"
                 "*or switch to auto mode*"
-            )
-        ])
+            ],
+        )
 
 
 # autouse is not handled in any special way currently
@@ -172,13 +167,11 @@ def test_strict_mode_marked_test_unmarked_autouse_fixture_warning(pytester: Pyte
         result.assert_outcomes(failed=1, warnings=2)
     else:
         result.assert_outcomes(failed=1, warnings=1)
-    result.stdout.fnmatch_lines([
-            (
-                "*pytest.UsageError*"
-                "*asyncio test 'test_anything' requested async *"
-                "*@pytest.fixture 'any_fixture' in strict mode. "
-                "*You might want to use @pytest_asyncio.fixture*"
-                "*or switch to auto mode*"
-            ),
+    result.stdout.fnmatch_lines(
+        [
+            "*asyncio test 'test_anything' requested async *"
+            "*@pytest.fixture 'any_fixture' in strict mode. *"
+            "*You might want to use @pytest_asyncio.fixture*"
+            "*or switch to auto mode*"
         ],
     )


### PR DESCRIPTION
### What was wrong?
using `@pytest.fixture` on async fixtures emitted only a deprecation warning, but plan was to make it an exception

Closes: #1202 
Related issue: #1202 

### How it was fixed?
- Raises ``pytest.UsageError`` instead of ``PytestDeprecationWarning`` when using ``@pytest.fixture`` on async fixtures in strict mode (I'm not really sure about ``pytest.UsageError`` because some different func uses usual ``ValueError``)
- Update test cases
- Add changelog entry

