### PR TITLE
fix: "The test […] is not an async function" when `asyncio` marker is

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -611,6 +611,19 @@ def pytest_pycollect_makeitem_convert_async_functions_to_subclass(
     hook_result.force_result(updated_node_collection)
 
 
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(items: list[Item]) -> None:
+    for i, item in enumerate(items):
+        if (
+            isinstance(item, Function)
+            and not isinstance(item, PytestAsyncioFunction)
+            and item.get_closest_marker("asyncio")
+        ):
+            specialized_item_class = PytestAsyncioFunction.item_subclass_for(item)
+            if specialized_item_class:
+                items[i] = specialized_item_class._from_function(item)
+
+
 @contextlib.contextmanager
 def _temporary_event_loop_policy(policy: AbstractEventLoopPolicy) -> Iterator[None]:
     old_loop_policy = _get_event_loop_policy()

--- a/tests/test_asyncio_mark.py
+++ b/tests/test_asyncio_mark.py
@@ -186,3 +186,33 @@ def test_asyncio_marker_uses_marker_loop_scope_even_if_config_is_set(
 
     result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(passed=1)
+
+
+def test_asyncio_mark_added_via_collection_modifyitems_is_recognized(
+    pytester: Pytester,
+):
+    """Regression test for #810.
+
+    When a user plugin adds the asyncio marker via pytest_collection_modifyitems,
+    pytest-asyncio should recognize the async function and run it correctly instead
+    of raising "The test is not an async function".
+    """
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makeconftest(
+        dedent("""\
+        import inspect
+
+        def pytest_collection_modifyitems(items):
+            for item in items:
+                if inspect.iscoroutinefunction(getattr(item, "obj", None)):
+                    item.add_marker("asyncio")
+        """)
+    )
+    pytester.makepyfile(
+        dedent("""\
+        async def test_foo():
+            pass
+        """)
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Fixes #810

When the `asyncio` marker is added to a test item via `pytest_collection_modifyitems` in user plugins, pytest-asyncio would raise "The test is not an async function" because `pytest_pycollect_makeitem_convert_async_functions_to_subclass` had already run and did not see the marker at collection time. The root cause was that async `Function` items marked after collection were never converted to `PytestAsyncioFunction` subclasses. Adds a `pytest_collection_modifyitems` hook in `pytest_asyncio/plugin.py` with `trylast=True` that iterates collected items and calls `PytestAsyncioFunction.item_subclass_for` and `_from_function` to perform the conversion for any `Function` carrying an `asyncio` marker that was not already specialized. Verified by the existing test suite covering the `pytest_collection_modifyitems` marker injection scenario introduced alongside this fix.