### PR TITLE
fix: Finish deprecation of unset asyncio_default_fixture_loop_scope

### DIFF
--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -113,7 +113,7 @@ def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager) -> None
         "asyncio_default_fixture_loop_scope",
         type="string",
         help="default scope of the asyncio event loop used to execute async fixtures",
-        default=None,
+        default="function",
     )
     parser.addini(
         "asyncio_default_test_loop_scope",
@@ -219,16 +219,6 @@ def _get_asyncio_debug(config: Config) -> bool:
         return val == "true"
 
 
-_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET = """\
-The configuration option "asyncio_default_fixture_loop_scope" is unset.
-The event loop scope for asynchronous fixtures will default to the "fixture" caching \
-scope. Future versions of pytest-asyncio will default the loop scope for asynchronous \
-fixtures to "function" scope. Set the default fixture loop scope explicitly in order \
-to avoid unexpected behavior in the future. Valid fixture loop scopes are: \
-"function", "class", "module", "package", "session"
-"""
-
-
 def _validate_scope(scope: str | None, option_name: str) -> None:
     if scope is None:
         return
@@ -243,8 +233,6 @@ def _validate_scope(scope: str | None, option_name: str) -> None:
 def pytest_configure(config: Config) -> None:
     default_fixture_loop_scope = config.getini("asyncio_default_fixture_loop_scope")
     _validate_scope(default_fixture_loop_scope, "asyncio_default_fixture_loop_scope")
-    if not default_fixture_loop_scope:
-        warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
 
     default_test_loop_scope = config.getini("asyncio_default_test_loop_scope")
     _validate_scope(default_test_loop_scope, "asyncio_default_test_loop_scope")


### PR DESCRIPTION
Fixes #924

Completes the deprecation of the unset `asyncio_default_fixture_loop_scope` configuration option. The deprecation warning introduced in a prior release was the interim step; the final behavior is to default the fixture loop scope to `"function"` rather than requiring users to set it explicitly. Changes `default=None` to `default="function"` in `pytest_addoption` and removes the `_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET` warning string and its associated `warnings.warn` call from `pytest_configure` in `pytest_asyncio/plugin.py`. Verified by confirming no warning is emitted when `asyncio_default_fixture_loop_scope` is unset and that fixture loop scope behavior matches the `"function"` default.