### PR TITLE
feat(workflows): add gh release instead of ncipollo/release-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,25 +195,15 @@ jobs:
       if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        VERSION: ${{ needs.build.outputs.version }}
         PRERELEASE: ${{ needs.build.outputs.prerelease }}
       run: |
         TAG_NAME="${GITHUB_REF#refs/tags/}"
 
-        IS_DRAFT=$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft' 2>/dev/null || echo "")
-        if [ -n "${IS_DRAFT}" ]; then
-          if [ "${IS_DRAFT}" = "false" ]; then
-            exit 0
-          fi
-          gh release edit "${TAG_NAME}" \
-            --title "pytest-asyncio ${VERSION}" \
-            --notes-file release-notes.md \
-            --draft
-
-          gh release upload "${TAG_NAME}" dist/* --clobber
-        else
+        gh release view "${TAG_NAME}" >/dev/null
+        RELEASE_EXISTS=$?
+        if [ $RELEASE_EXISTS -ne 0 ]; then
           gh release create "${TAG_NAME}" \
-            --title "pytest-asyncio ${VERSION}" \
+            --title "pytest-asyncio ${TAG_NAME}" \
             --notes-file release-notes.md \
             --draft \
             $( [ "${PRERELEASE}" = "true" ] && echo "--prerelease" ) \

--- a/changelog.d/1392.changed.rst
+++ b/changelog.d/1392.changed.rst
@@ -1,1 +1,0 @@
-Change ``ncipollo/release-action`` on ``gh release``


### PR DESCRIPTION
### What was wrong?

Due to security issues with `ncipollo/release-action` need to remove this dependency and replace with `gh release`

Closes: #1382
Related: #1382

### How it was fixed?

The release logic previously implemented via `ncipollo/release-action` has been reimplemented using the `gh`

Our workflow now relied on two key flags:
- `allowUpdates: true`
- `skipIfReleaseExists: true`

These flags overlap in behavior at least semantically and the [ncipollo documentation](https://github.com/ncipollo/release-action)￼ doesn't clearly define their interaction or precedence. Based on the existing workflow, i was reimplemented as follows with this idea:

```sh
if release exists:
    if draft:
        gh release edit
    if published:
        exit
else:
    gh release create
```

I tried run jobs for check how release creating [here](https://github.com/dzhalaevd/pytest-asyncio/releases)
and re-run for checking how it was updates

