### PR TITLE
chore(`.github`): add chronographer config

### DIFF
--- a/.github/chronographer.yml
+++ b/.github/chronographer.yml
@@ -1,0 +1,14 @@
+---
+branch-protection-check-name: Timeline protection
+action-hints:
+  inline-markdown: |
+    This PR is missing news fragments.
+
+    Add a file under `changelog.d/`, like:
+    `123.changed.rst`. You can use the Towncrier CLI to create it. Make sure to match the writing style with the existing change log content.
+
+    If this change isn't user-facing, ask the maintainers to apply the `skip-changelog` label. Please, include a justification.
+enforce-name:
+  suffix: .rst
+labels:
+  skip-changelog: skip-changelog


### PR DESCRIPTION
### What was wrong?

Need extra settings to chronographer for skipping check pr which has `skip-changelog` because a few PR is internal and non affect on user

Closes: #1407

### How it was fixed

Add new behavior is using the `skip-changelog` label to skip changelog checks
Note: We need to be create new label