### PR TITLE
Point to *stable* documentation version, instead of *latest*

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ pytest-asyncio
     :alt: Matrix chat room: #pytest-asyncio
     :target: https://matrix.to/#/#pytest-asyncio:matrix.org
 
-`pytest-asyncio <https://pytest-asyncio.readthedocs.io/en/latest/>`_ is a `pytest <https://docs.pytest.org/en/latest/contents.html>`_ plugin. It facilitates testing of code that uses the `asyncio <https://docs.python.org/3/library/asyncio.html>`_ library.
+`pytest-asyncio <https://pytest-asyncio.readthedocs.io/en/stable/>`_ is a `pytest <https://docs.pytest.org/en/latest/contents.html>`_ plugin. It facilitates testing of code that uses the `asyncio <https://docs.python.org/3/library/asyncio.html>`_ library.
 
 Specifically, pytest-asyncio provides support for coroutines as test functions. This allows users to *await* code inside their tests. For example, the following code is executed as a test item by pytest:
 
@@ -25,7 +25,7 @@ Specifically, pytest-asyncio provides support for coroutines as test functions. 
         res = await library.do_something()
         assert b"expected result" == res
 
-More details can be found in the `documentation <https://pytest-asyncio.readthedocs.io/en/latest/>`_.
+More details can be found in the `documentation <https://pytest-asyncio.readthedocs.io/en/stable/>`_.
 
 Note that test classes subclassing the standard `unittest <https://docs.python.org/3/library/unittest.html>`__ library are not supported. Users
 are advised to use `unittest.IsolatedAsyncioTestCase <https://docs.python.org/3/library/unittest.html#unittest.IsolatedAsyncioTestCase>`__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ optional-dependencies.testing = [
   "hypothesis>=5.7.1",
 ]
 urls."Bug Tracker" = "https://github.com/pytest-dev/pytest-asyncio/issues"
-urls.Changelog = "https://pytest-asyncio.readthedocs.io/en/latest/reference/changelog.html"
+urls.Changelog = "https://pytest-asyncio.readthedocs.io/en/stable/reference/changelog.html"
 urls.Documentation = "https://pytest-asyncio.readthedocs.io"
 urls.Homepage = "https://github.com/pytest-dev/pytest-asyncio"
 urls."Source Code" = "https://github.com/pytest-dev/pytest-asyncio"


### PR DESCRIPTION
The README (as pointed out in  [this comment](https://github.com/pytest-dev/pytest-asyncio/issues/1070#issuecomment-3175981552)) and *pyproject.toml* point to the *latest* version of the documentation. The *latest* is the one generated by the *main* branch.

If the documentation on *main* is different from the most recent release, this can create confusion for users.

This patch changes the links to the *stable* documentation version.