### PR TITLE
Add pytest main CI smoke test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
         if-no-files-found: error
 
   test-pytest-dev:
-    name: ubuntu - Python ${{ env.PYTHON_LATEST }} - pytest main
+    name: ubuntu - Python latest - pytest main
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -116,11 +116,9 @@ jobs:
         python -VV
         python -m site
         python -m pip install --upgrade pip
-        python -m pip install --upgrade \
-          ".[testing]" \
-          "pytest @ git+https://github.com/pytest-dev/pytest.git"
+        python -m pip install --upgrade tox
     - name: Run tests against pytest main
-      run: make test
+      run: python -m tox run -e pytest-dev
 
   lint-github-actions:
     name: Lint GitHub Actions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,28 @@ jobs:
         path: coverage/coverage.*
         if-no-files-found: error
 
+  test-pytest-dev:
+    name: ubuntu - Python ${{ env.PYTHON_LATEST }} - pytest main
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      with:
+        python-version: ${{ env.PYTHON_LATEST }}
+    - name: Install dependencies
+      run: |
+        python -VV
+        python -m site
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade \
+          ".[testing]" \
+          "pytest @ git+https://github.com/pytest-dev/pytest.git"
+    - name: Run tests against pytest main
+      run: make test
+
   lint-github-actions:
     name: Lint GitHub Actions
     permissions:

--- a/tests/modes/test_strict_mode.py
+++ b/tests/modes/test_strict_mode.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from textwrap import dedent
 
+import pytest
 from pytest import Pytester, version_tuple as pytest_version
 
 
@@ -82,6 +83,10 @@ def test_strict_mode_ignores_unmarked_coroutine(pytester: Pytester):
     result.stdout.fnmatch_lines(["*async def functions are not natively supported*"])
 
 
+@pytest.mark.skipif(
+    pytest_version >= (9, 1, 0),
+    reason="pytest >=9.1 converts unhandled async fixtures to errors",
+)
 def test_strict_mode_ignores_unmarked_fixture(pytester: Pytester):
     pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(dedent("""\
@@ -109,6 +114,10 @@ def test_strict_mode_ignores_unmarked_fixture(pytester: Pytester):
     )
 
 
+@pytest.mark.skipif(
+    pytest_version >= (9, 1, 0),
+    reason="pytest >=9.1 converts unhandled async fixtures to errors",
+)
 def test_strict_mode_marked_test_unmarked_fixture_warning(pytester: Pytester):
     pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(dedent("""\
@@ -152,6 +161,10 @@ def test_strict_mode_marked_test_unmarked_fixture_warning(pytester: Pytester):
 
 
 # autouse is not handled in any special way currently
+@pytest.mark.skipif(
+    pytest_version >= (9, 1, 0),
+    reason="pytest >=9.1 converts unhandled async fixtures to errors",
+)
 def test_strict_mode_marked_test_unmarked_autouse_fixture_warning(pytester: Pytester):
     pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
     pytester.makepyfile(dedent("""\

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,12 @@ commands = make test
 allowlist_externals =
     make
 
+[testenv:pytest-dev]
+description = Run tests against pytest main
+constraints =
+deps =
+    pytest @ git+https://github.com/pytest-dev/pytest.git
+
 [testenv:docs]
 allowlist_externals =
     git


### PR DESCRIPTION
Fixes #1132.

This adds a separate non-blocking CI job that installs pytest from the pytest main branch and runs the existing test target against it. The regular tox matrix stays unchanged.