### PR TITLE
test: regression test for #403 (mock.patch.dict + asyncio_mode=auto)

### DIFF
--- a/changelog.d/403.fixed.rst
+++ b/changelog.d/403.fixed.rst
@@ -1,0 +1,1 @@
+Added a regression test ensuring async tests decorated with ``unittest.mock.patch.dict`` are not silently skipped in ``asyncio_mode=auto``.

--- a/tests/modes/test_auto_mode.py
+++ b/tests/modes/test_auto_mode.py
@@ -126,3 +126,34 @@ def test_auto_mode_static_method_fixture(pytester: Pytester):
         """))
     result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(passed=1)
+
+
+def test_auto_mode_async_test_with_mock_patch_dict(pytester: Pytester):
+    # Regression test for #403: async tests decorated with
+    # unittest.mock.patch.dict were silently skipped in auto mode on
+    # Python 3.8 / 3.9. CPython fixed the underlying iscoroutinefunction
+    # behavior of patch.dict in 3.10 (backported); pytest-asyncio now
+    # requires Python >= 3.10, so the scenario must run cleanly.
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(dedent("""\
+        from unittest import mock
+
+        import pytest
+
+        pytest_plugins = 'pytest_asyncio'
+
+        bar = {}
+
+
+        @mock.patch.dict("test_auto_mode_async_test_with_mock_patch_dict.bar")
+        async def test_decorated_with_patch_dict():
+            pass
+
+
+        @pytest.mark.asyncio
+        @mock.patch.dict("test_auto_mode_async_test_with_mock_patch_dict.bar")
+        async def test_marked_and_decorated_with_patch_dict():
+            pass
+        """))
+    result = pytester.runpytest("--asyncio-mode=auto")
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
## Summary

#403 reported that async tests decorated with `unittest.mock.patch.dict` were silently skipped under `asyncio_mode=auto`, surfaced as a `PytestUnhandledCoroutineWarning`. The root cause was a CPython bug in how `iscoroutinefunction` unwrapped `patch.dict`. seifertm filed [python/cpython#98086](https://github.com/python/cpython/issues/98086) and the fix was backported to CPython 3.10 (and 3.11). pytest-asyncio now requires Python >= 3.10, so the scenario is no longer reachable.

This PR adds a regression test in `tests/modes/test_auto_mode.py` to lock that property in. The test reproduces the issue's two failing variants - `test_doesnt_run` (only decorated with `@mock.patch.dict`) and `test_runs_anyway` (also explicitly marked `@pytest.mark.asyncio`) - and asserts both are collected and pass under `--asyncio-mode=auto`. If a future refactor reintroduces the unwrapping bug at this layer (e.g. switching back to a `iscoroutinefunction` call that doesn't see through `patch.dict`), this test fails immediately.

## Files

- `tests/modes/test_auto_mode.py`: new `test_auto_mode_async_test_with_mock_patch_dict` test
- `changelog.d/403.fixed.rst`: news fragment

## Verification

```
$ pytest tests/modes/test_auto_mode.py -v
...
tests/modes/test_auto_mode.py::test_auto_mode_cmdline PASSED             [ 14%]
tests/modes/test_auto_mode.py::test_auto_mode_cfg PASSED                 [ 28%]
tests/modes/test_auto_mode.py::test_auto_mode_async_fixture PASSED       [ 42%]
tests/modes/test_auto_mode.py::test_auto_mode_method_fixture PASSED      [ 57%]
tests/modes/test_auto_mode.py::test_auto_mode_static_method PASSED       [ 71%]
tests/modes/test_auto_mode.py::test_auto_mode_static_method_fixture PASSED [ 85%]
tests/modes/test_auto_mode.py::test_auto_mode_async_test_with_mock_patch_dict PASSED [100%]
============================== 7 passed in 0.11s ===============================
```

Also verified the original repro from the issue body runs cleanly under Python 3.14.3 + current pytest-asyncio main (3/3 passed), confirming the CPython backport is the right reason this test passes today rather than a workaround in this repo.

Closes #403

AI disclosure: regression test and PR body drafted with Claude as a coding assistant; I ran the tests and reviewed the changes before pushing.
