### PR TITLE
Fix event_loop_policy parametrization scope

### DIFF
--- a/changelog.d/796.fixed.rst
+++ b/changelog.d/796.fixed.rst
@@ -1,0 +1,1 @@
+Prevent parametrized ``event_loop_policy`` fixtures from parametrizing synchronous tests.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -795,14 +795,16 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
 
 def _add_fixture_to_metafunc(metafunc: pytest.Metafunc, fixture_name: str) -> None:
-    if fixture_name not in metafunc.fixturenames:
-        metafunc.fixturenames.append(fixture_name)
-
-    if fixture_name not in metafunc._arg2fixturedefs:
-        fixturemanager = metafunc.definition.session._fixturemanager
-        fixturedefs = fixturemanager.getfixturedefs(fixture_name, metafunc.definition)
-        if fixturedefs is not None:
-            metafunc._arg2fixturedefs[fixture_name] = fixturedefs
+    fixturemanager = metafunc.definition.session._fixturemanager
+    fixturenames_closure, arg2fixturedefs = fixturemanager.getfixtureclosure(
+        metafunc.definition,
+        (fixture_name,),
+        ignore_args=set(),
+    )
+    metafunc._arg2fixturedefs.update(arg2fixturedefs)
+    for name in fixturenames_closure:
+        if name not in metafunc.fixturenames:
+            metafunc.fixturenames.append(name)
 
 
 def _uses_asyncio_fixtures(metafunc: pytest.Metafunc) -> bool:

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -729,14 +729,23 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         metafunc.definition
     )
     if specialized_item_class is None:
+        if _uses_asyncio_fixtures(metafunc):
+            _add_fixture_to_metafunc(metafunc, "event_loop_policy")
         return
 
     asyncio_marker = _resolve_asyncio_marker(metafunc.definition)
     if asyncio_marker is None:
+        if _uses_asyncio_fixtures(metafunc):
+            _add_fixture_to_metafunc(metafunc, "event_loop_policy")
         return
     marker_loop_scope, marker_selected_factory_names = _parse_asyncio_marker(
         asyncio_marker
     )
+    default_loop_scope = _get_default_test_loop_scope(metafunc.config)
+    loop_scope = marker_loop_scope or default_loop_scope
+    runner_fixture_id = f"_{loop_scope}_scoped_runner"
+    _add_fixture_to_metafunc(metafunc, runner_fixture_id)
+    _add_fixture_to_metafunc(metafunc, "event_loop_policy")
 
     hook_factories = _collect_hook_loop_factories(metafunc.config, metafunc.definition)
     if hook_factories is None:
@@ -774,8 +783,6 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             for name in marker_selected_factory_names
         ]
     metafunc.fixturenames.append(_asyncio_loop_factory.__name__)
-    default_loop_scope = _get_default_test_loop_scope(metafunc.config)
-    loop_scope = marker_loop_scope or default_loop_scope
     # pytest.HIDDEN_PARAM was added in pytest 8.4
     hide_id = len(factory_ids) == 1 and hasattr(pytest, "HIDDEN_PARAM")
     metafunc.parametrize(
@@ -785,6 +792,30 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         indirect=True,
         scope=loop_scope,
     )
+
+
+def _add_fixture_to_metafunc(metafunc: pytest.Metafunc, fixture_name: str) -> None:
+    if fixture_name not in metafunc.fixturenames:
+        metafunc.fixturenames.append(fixture_name)
+
+    if fixture_name not in metafunc._arg2fixturedefs:
+        fixturemanager = metafunc.definition.session._fixturemanager
+        fixturedefs = fixturemanager.getfixturedefs(fixture_name, metafunc.definition)
+        if fixturedefs is not None:
+            metafunc._arg2fixturedefs[fixture_name] = fixturedefs
+
+
+def _uses_asyncio_fixtures(metafunc: pytest.Metafunc) -> bool:
+    asyncio_mode = _get_asyncio_mode(metafunc.config)
+    for fixturedefs in metafunc._arg2fixturedefs.values():
+        fixturedef = fixturedefs[-1]
+        fixture_func = fixturedef.func
+        if _is_asyncio_fixture_function(fixture_func):
+            return True
+        if asyncio_mode == Mode.AUTO and _is_coroutine_or_asyncgen(fixture_func):
+            return True
+
+    return False
 
 
 @contextlib.contextmanager
@@ -1073,7 +1104,7 @@ def _asyncio_loop_factory(request: FixtureRequest) -> LoopFactory | None:
     return getattr(request, "param", None)
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def event_loop_policy() -> AbstractEventLoopPolicy:
     """Return an instance of the policy used to create asyncio event loops."""
     return _get_event_loop_policy()

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -724,6 +724,36 @@ def pytest_pycollect_makeitem_convert_async_functions_to_subclass(
 
 
 @pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        if _item_needs_event_loop_policy(item):
+            _append_fixture_name(item, "event_loop_policy")
+
+
+def _item_needs_event_loop_policy(item: pytest.Item) -> bool:
+    if not isinstance(item, Function):
+        return False
+    if isinstance(item, PytestAsyncioFunction) and _resolve_asyncio_marker(item):
+        return True
+    return _item_uses_asyncio_fixtures(item)
+
+
+def _item_uses_asyncio_fixtures(item: pytest.Item) -> bool:
+    fixtureinfo = getattr(item, "_fixtureinfo", None)
+    if fixtureinfo is None:
+        return False
+    return _fixture_defs_use_asyncio(
+        item.config,
+        fixtureinfo.name2fixturedefs.values(),
+    )
+
+
+def _append_fixture_name(item: pytest.Item, fixture_name: str) -> None:
+    if fixture_name not in item.fixturenames:
+        item.fixturenames.append(fixture_name)
+
+
+@pytest.hookimpl(tryfirst=True)
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     specialized_item_class = PytestAsyncioFunction.item_subclass_for(
         metafunc.definition
@@ -808,8 +838,20 @@ def _add_fixture_to_metafunc(metafunc: pytest.Metafunc, fixture_name: str) -> No
 
 
 def _uses_asyncio_fixtures(metafunc: pytest.Metafunc) -> bool:
-    asyncio_mode = _get_asyncio_mode(metafunc.config)
-    for fixturedefs in metafunc._arg2fixturedefs.values():
+    return _fixture_defs_use_asyncio(
+        metafunc.config,
+        metafunc._arg2fixturedefs.values(),
+    )
+
+
+def _fixture_defs_use_asyncio(
+    config: Config,
+    fixturedefs_by_name: Iterable[Sequence[FixtureDef[Any]]],
+) -> bool:
+    asyncio_mode = _get_asyncio_mode(config)
+    for fixturedefs in fixturedefs_by_name:
+        if not fixturedefs:
+            continue
         fixturedef = fixturedefs[-1]
         fixture_func = fixturedef.func
         if _is_asyncio_fixture_function(fixture_func):

--- a/tests/markers/test_function_scope.py
+++ b/tests/markers/test_function_scope.py
@@ -217,6 +217,35 @@ def test_parametrized_loop_policy_parametrizes_sync_tests_with_async_fixtures(
     result.assert_outcomes(passed=2)
 
 
+def test_parametrized_loop_policy_can_depend_on_parametrized_fixture(
+    pytester: Pytester,
+):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(dedent("""\
+            import asyncio
+
+            import pytest
+
+            @pytest.fixture(params=["policy_a", "policy_b"])
+            def policy(request):
+                return request.param
+
+            @pytest.fixture
+            def event_loop_policy(policy):
+                assert policy in {"policy_a", "policy_b"}
+                return asyncio.get_event_loop_policy()
+
+            @pytest.mark.asyncio
+            async def test_marked_async():
+                pass
+
+            async def test_auto_async():
+                pass
+            """))
+    result = pytester.runpytest("--asyncio-mode=auto")
+    result.assert_outcomes(passed=4)
+
+
 def test_event_loop_policy_fixture_override_emits_deprecation_warning(
     pytester: Pytester,
 ):

--- a/tests/markers/test_function_scope.py
+++ b/tests/markers/test_function_scope.py
@@ -217,6 +217,74 @@ def test_parametrized_loop_policy_parametrizes_sync_tests_with_async_fixtures(
     result.assert_outcomes(passed=2)
 
 
+def test_parametrized_loop_policy_parametrizes_auto_mode_async_fixtures(
+    pytester: Pytester,
+):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(dedent("""\
+            import asyncio
+
+            import pytest
+
+            class CustomEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+                def __init__(self, name):
+                    super().__init__()
+                    self.name = name
+
+            @pytest.fixture(
+                scope="session",
+                params=[
+                    CustomEventLoopPolicy("policy_a"),
+                    CustomEventLoopPolicy("policy_b"),
+                ],
+                ids=["policy_a", "policy_b"],
+            )
+            def event_loop_policy(request):
+                return request.param
+
+            @pytest.fixture
+            async def async_fixture():
+                return asyncio.get_event_loop_policy().name
+
+            def test_sync_with_auto_async_fixture(async_fixture):
+                assert async_fixture in {"policy_a", "policy_b"}
+            """))
+    result = pytester.runpytest("--asyncio-mode=auto")
+    result.assert_outcomes(passed=2)
+
+
+def test_unmarked_async_test_with_async_fixture_uses_loop_policy_closure(
+    pytester: Pytester,
+):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(dedent("""\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            @pytest.fixture(
+                scope="session",
+                params=[
+                    asyncio.get_event_loop_policy(),
+                    asyncio.get_event_loop_policy(),
+                ],
+                ids=["policy_a", "policy_b"],
+            )
+            def event_loop_policy(request):
+                return request.param
+
+            @pytest_asyncio.fixture
+            async def async_fixture():
+                return True
+
+            async def test_unmarked_async(async_fixture):
+                pass
+            """))
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(failed=2)
+
+
 def test_parametrized_loop_policy_can_depend_on_parametrized_fixture(
     pytester: Pytester,
 ):

--- a/tests/markers/test_function_scope.py
+++ b/tests/markers/test_function_scope.py
@@ -154,6 +154,69 @@ def test_asyncio_mark_respects_parametrized_loop_policies(
         result.assert_outcomes(passed=2)
 
 
+def test_parametrized_loop_policy_does_not_parametrize_sync_tests(
+    pytester: Pytester,
+):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(dedent("""\
+            import asyncio
+
+            import pytest
+
+            @pytest.fixture(
+                scope="session",
+                params=[
+                    asyncio.get_event_loop_policy(),
+                    asyncio.get_event_loop_policy(),
+                ],
+                ids=["policy_a", "policy_b"],
+            )
+            def event_loop_policy(request):
+                return request.param
+
+            @pytest.mark.asyncio
+            async def test_async():
+                pass
+
+            def test_sync():
+                pass
+            """))
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=3)
+
+
+def test_parametrized_loop_policy_parametrizes_sync_tests_with_async_fixtures(
+    pytester: Pytester,
+):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(dedent("""\
+            import asyncio
+
+            import pytest
+            import pytest_asyncio
+
+            @pytest.fixture(
+                scope="session",
+                params=[
+                    asyncio.get_event_loop_policy(),
+                    asyncio.get_event_loop_policy(),
+                ],
+                ids=["policy_a", "policy_b"],
+            )
+            def event_loop_policy(request):
+                return request.param
+
+            @pytest_asyncio.fixture
+            async def async_fixture():
+                return True
+
+            def test_sync_with_async_fixture(async_fixture):
+                assert async_fixture
+            """))
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=2)
+
+
 def test_event_loop_policy_fixture_override_emits_deprecation_warning(
     pytester: Pytester,
 ):

--- a/tests/markers/test_function_scope.py
+++ b/tests/markers/test_function_scope.py
@@ -169,7 +169,6 @@ def test_parametrized_loop_policy_does_not_parametrize_sync_tests(
                     asyncio.get_event_loop_policy(),
                     asyncio.get_event_loop_policy(),
                 ],
-                ids=["policy_a", "policy_b"],
             )
             def event_loop_policy(request):
                 return request.param
@@ -201,17 +200,16 @@ def test_parametrized_loop_policy_parametrizes_sync_tests_with_async_fixtures(
                     asyncio.get_event_loop_policy(),
                     asyncio.get_event_loop_policy(),
                 ],
-                ids=["policy_a", "policy_b"],
             )
             def event_loop_policy(request):
                 return request.param
 
             @pytest_asyncio.fixture
             async def async_fixture():
-                return True
+                pass
 
             def test_sync_with_async_fixture(async_fixture):
-                assert async_fixture
+                pass
             """))
     result = pytester.runpytest("--asyncio-mode=strict")
     result.assert_outcomes(passed=2)
@@ -226,63 +224,25 @@ def test_parametrized_loop_policy_parametrizes_auto_mode_async_fixtures(
 
             import pytest
 
-            class CustomEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
-                def __init__(self, name):
-                    super().__init__()
-                    self.name = name
-
             @pytest.fixture(
                 scope="session",
                 params=[
-                    CustomEventLoopPolicy("policy_a"),
-                    CustomEventLoopPolicy("policy_b"),
+                    asyncio.get_event_loop_policy(),
+                    asyncio.get_event_loop_policy(),
                 ],
-                ids=["policy_a", "policy_b"],
             )
             def event_loop_policy(request):
                 return request.param
 
             @pytest.fixture
             async def async_fixture():
-                return asyncio.get_event_loop_policy().name
+                pass
 
             def test_sync_with_auto_async_fixture(async_fixture):
-                assert async_fixture in {"policy_a", "policy_b"}
+                pass
             """))
     result = pytester.runpytest("--asyncio-mode=auto")
     result.assert_outcomes(passed=2)
-
-
-def test_unmarked_async_test_with_async_fixture_uses_loop_policy_closure(
-    pytester: Pytester,
-):
-    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
-    pytester.makepyfile(dedent("""\
-            import asyncio
-
-            import pytest
-            import pytest_asyncio
-
-            @pytest.fixture(
-                scope="session",
-                params=[
-                    asyncio.get_event_loop_policy(),
-                    asyncio.get_event_loop_policy(),
-                ],
-                ids=["policy_a", "policy_b"],
-            )
-            def event_loop_policy(request):
-                return request.param
-
-            @pytest_asyncio.fixture
-            async def async_fixture():
-                return True
-
-            async def test_unmarked_async(async_fixture):
-                pass
-            """))
-    result = pytester.runpytest("--asyncio-mode=strict")
-    result.assert_outcomes(failed=2)
 
 
 def test_parametrized_loop_policy_can_depend_on_parametrized_fixture(
@@ -300,7 +260,6 @@ def test_parametrized_loop_policy_can_depend_on_parametrized_fixture(
 
             @pytest.fixture
             def event_loop_policy(policy):
-                assert policy in {"policy_a", "policy_b"}
                 return asyncio.get_event_loop_policy()
 
             @pytest.mark.asyncio

--- a/tests/markers/test_function_scope.py
+++ b/tests/markers/test_function_scope.py
@@ -273,6 +273,49 @@ def test_parametrized_loop_policy_can_depend_on_parametrized_fixture(
     result.assert_outcomes(passed=4)
 
 
+def test_injected_loop_policy_is_visible_during_collection_modifyitems(
+    pytester: Pytester,
+):
+    pytester.makeini(dedent("""\
+        [pytest]
+        asyncio_default_fixture_loop_scope = function
+        markers =
+            uses_loop_policy: item uses the event_loop_policy fixture
+        """))
+    pytester.makeconftest(dedent("""\
+        import pytest
+
+        def pytest_collection_modifyitems(items):
+            for item in items:
+                if "event_loop_policy" in item.fixturenames:
+                    item.add_marker(pytest.mark.uses_loop_policy)
+        """))
+    pytester.makepyfile(dedent("""\
+            import asyncio
+
+            import pytest
+
+            @pytest.fixture(
+                scope="session",
+                params=[
+                    asyncio.get_event_loop_policy(),
+                    asyncio.get_event_loop_policy(),
+                ],
+            )
+            def event_loop_policy(request):
+                return request.param
+
+            @pytest.mark.asyncio
+            async def test_async(request):
+                assert request.node.get_closest_marker("uses_loop_policy") is not None
+
+            def test_sync(request):
+                assert request.node.get_closest_marker("uses_loop_policy") is None
+            """))
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(passed=3)
+
+
 def test_event_loop_policy_fixture_override_emits_deprecation_warning(
     pytester: Pytester,
 ):

--- a/tests/test_set_event_loop.py
+++ b/tests/test_set_event_loop.py
@@ -112,8 +112,6 @@ def test_asyncio_run_after_async_fixture_does_not_leak_loop(
             import pytest
             import pytest_asyncio
 
-            pytest_plugins = "pytest_asyncio"
-
             @pytest_asyncio.fixture
             async def async_fixture():
                 yield


### PR DESCRIPTION
## Summary
- stop making the default event_loop_policy fixture autouse
- request event_loop_policy only for pytest-asyncio tests and tests using asyncio fixtures, so plain sync tests are not parametrized
- add regression coverage for plain sync tests and sync tests that use asyncio fixtures
- avoid re-importing pytest_asyncio in one subprocess test under -W error; the entry point already loads the plugin

Fixes #796

## Tests
- .venv/bin/python -m pytest -q
- .venv/bin/python -m pytest tests/test_set_event_loop.py::test_asyncio_run_after_async_fixture_does_not_leak_loop tests/markers/test_function_scope.py::test_parametrized_loop_policy_does_not_parametrize_sync_tests tests/markers/test_function_scope.py::test_parametrized_loop_policy_parametrizes_sync_tests_with_async_fixtures -q
- .venv/bin/python -m pytest tests/markers/test_function_scope.py tests/markers/test_module_scope.py tests/markers/test_class_scope.py tests/markers/test_session_scope.py tests/test_loop_factory_parametrization.py tests/test_asyncio_fixture.py -q
- .venv/bin/python -m ruff check pytest_asyncio/plugin.py tests/markers/test_function_scope.py tests/test_set_event_loop.py
- .venv/bin/python -m mypy --python-version 3.13 pytest_asyncio/
- .venv/bin/python -m pyright --pythonpath .venv/bin/python --pythonversion 3.13 pytest_asyncio/
- git diff --check