### PR TITLE
fix: default asyncio_default_fixture_loop_scope to "function"

### DIFF
--- a/changelog.d/924.changed.rst
+++ b/changelog.d/924.changed.rst
@@ -1,0 +1,3 @@
+``asyncio_default_fixture_loop_scope`` now defaults to ``"function"`` instead of being unset.
+Previously, leaving the option unset caused a ``PytestDeprecationWarning`` on every test run.
+The old deprecation warning and its associated constant have been removed.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -271,8 +271,6 @@ def _collect_hook_loop_factories(
     return factories
 
 
-
-
 def _validate_scope(scope: str | None, option_name: str) -> None:
     if scope is None:
         return

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -137,7 +137,7 @@ def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager) -> None
         "asyncio_default_fixture_loop_scope",
         type="string",
         help="default scope of the asyncio event loop used to execute async fixtures",
-        default=None,
+        default="function",
     )
     parser.addini(
         "asyncio_default_test_loop_scope",
@@ -271,14 +271,6 @@ def _collect_hook_loop_factories(
     return factories
 
 
-_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET = """\
-The configuration option "asyncio_default_fixture_loop_scope" is unset.
-The event loop scope for asynchronous fixtures will default to the "fixture" caching \
-scope. Future versions of pytest-asyncio will default the loop scope for asynchronous \
-fixtures to "function" scope. Set the default fixture loop scope explicitly in order \
-to avoid unexpected behavior in the future. Valid fixture loop scopes are: \
-"function", "class", "module", "package", "session"
-"""
 
 
 def _validate_scope(scope: str | None, option_name: str) -> None:
@@ -295,9 +287,6 @@ def _validate_scope(scope: str | None, option_name: str) -> None:
 def pytest_configure(config: Config) -> None:
     default_fixture_loop_scope = config.getini("asyncio_default_fixture_loop_scope")
     _validate_scope(default_fixture_loop_scope, "asyncio_default_fixture_loop_scope")
-    if not default_fixture_loop_scope:
-        warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
-
     default_test_loop_scope = config.getini("asyncio_default_test_loop_scope")
     _validate_scope(default_test_loop_scope, "asyncio_default_test_loop_scope")
     config.addinivalue_line(


### PR DESCRIPTION
## Summary

Closes #924.

The `asyncio_default_fixture_loop_scope` ini option was left `None` by default, which triggered a `PytestDeprecationWarning` on every test run and caused async fixtures to fall back to the old fixture-caching scope behaviour.

This PR completes the deprecation by:

1. **Setting the default to `"function"`** — the value the deprecation warning was telling users to set explicitly.
2. **Removing `_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET`** — the warning constant is now unreachable since the default is no longer falsy.
3. **Removing the `if not default_fixture_loop_scope: warnings.warn(...)` block** in `pytest_configure`.

## Before

```ini
# No ini setting needed, but you got a warning every run:
# PytestDeprecationWarning: The configuration option
#   "asyncio_default_fixture_loop_scope" is unset. ...
```

## After

```ini
# No ini setting needed, no warning.
# Fixtures default to "function" scope.
```

## Follow-up

Tests that explicitly set `asyncio_default_fixture_loop_scope = function` in pytester configs are now setting the default redundantly. Cleaning those up is a separate, mechanical follow-up.