### PR TITLE
Deprecate @pytest_asyncio.fixture for synchronous fixtures

### DIFF
--- a/changelog.d/1090.deprecated.rst
+++ b/changelog.d/1090.deprecated.rst
@@ -1,0 +1,1 @@
+Using :func:`pytest_asyncio.fixture` to decorate synchronous fixtures is now deprecated. Use :func:`pytest.fixture` instead.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -14,8 +14,6 @@ import traceback
 import warnings
 from asyncio import AbstractEventLoop
 from collections.abc import (
-    AsyncIterator,
-    Awaitable,
     Callable,
     Collection,
     Generator,
@@ -69,7 +67,7 @@ if TYPE_CHECKING:
     from asyncio import AbstractEventLoopPolicy
 
 _ScopeName = Literal["session", "package", "module", "class", "function"]
-_R = TypeVar("_R", bound=Awaitable[Any] | AsyncIterator[Any])
+_R = TypeVar("_R")
 _P = ParamSpec("_P")
 FixtureFunction = Callable[_P, _R]
 LoopFactory: TypeAlias = Callable[[], AbstractEventLoop]
@@ -211,6 +209,19 @@ def _make_asyncio_fixture_function(obj: Any, loop_scope: _ScopeName | None) -> N
     if hasattr(obj, "__func__"):
         # instance method, check the function object
         obj = obj.__func__
+    if not _is_coroutine_or_asyncgen(obj):
+        warnings.warn(
+            PytestDeprecationWarning(
+                "@pytest_asyncio.fixture was applied to the synchronous function "
+                f"{obj.__name__!r}. Use @pytest.fixture for synchronous fixtures. "
+                "This will become an error in future versions of pytest-asyncio."
+            ),
+            stacklevel=3,
+            # stacklevel=3 points at the user's @pytest_asyncio.fixture line for
+            # the bare-decorator path (user → fixture() → here). The factory path
+            # (@pytest_asyncio.fixture(...)) adds one extra frame via inner(), so
+            # the warning lands on plugin.py:inner instead — still the plugin.
+        )
     obj._force_asyncio_fixture = True
     obj._loop_scope = loop_scope
 
@@ -938,7 +949,8 @@ def pytest_fixture_setup(fixturedef: FixtureDef, request) -> object | None:
         functools.partial(fixturedef.finish, request=request)
     )
     synchronizer = _fixture_synchronizer(fixturedef, runner, request)
-    _make_asyncio_fixture_function(synchronizer, loop_scope)
+    synchronizer._force_asyncio_fixture = True  # type: ignore[attr-defined]
+    synchronizer._loop_scope = loop_scope  # type: ignore[attr-defined]
     with MonkeyPatch.context() as c:
         c.setattr(fixturedef, "func", synchronizer)
         hook_result = yield

--- a/tests/test_asyncio_fixture.py
+++ b/tests/test_asyncio_fixture.py
@@ -62,3 +62,55 @@ def test_sync_function_uses_async_fixture(pytester: Pytester, mode):
         """))
     result = pytester.runpytest(f"--asyncio-mode={mode}")
     result.assert_outcomes(passed=1)
+
+
+def test_sync_fixture_emits_deprecation_warning(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(dedent("""\
+        import pytest
+        import pytest_asyncio
+
+        @pytest_asyncio.fixture
+        def sync_fixture():
+            return 42
+
+        @pytest.mark.asyncio
+        async def test_uses_sync(sync_fixture):
+            assert sync_fixture == 42
+        """))
+    result = pytester.runpytest("-W", "default")
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(
+        [
+            (
+                "*PytestDeprecationWarning*@pytest_asyncio.fixture*"
+                "*sync_fixture*@pytest.fixture*"
+            )
+        ]
+    )
+
+
+def test_sync_fixture_factory_path_emits_deprecation_warning(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(dedent("""\
+        import pytest
+        import pytest_asyncio
+
+        @pytest_asyncio.fixture(loop_scope="function")
+        def sync_fixture():
+            return 42
+
+        @pytest.mark.asyncio
+        async def test_uses_sync(sync_fixture):
+            assert sync_fixture == 42
+        """))
+    result = pytester.runpytest("-W", "default")
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(
+        [
+            (
+                "*PytestDeprecationWarning*@pytest_asyncio.fixture*"
+                "*sync_fixture*@pytest.fixture*"
+            )
+        ]
+    )


### PR DESCRIPTION
Using `@pytest_asyncio.fixture` on a synchronous function is a user mistake — synchronous fixtures should use `@pytest.fixture`. Previously this silently succeeded, making the error hard to diagnose.

This PR:
- Widens `_R = TypeVar("_R")` (removes the `Awaitable | AsyncIterator` bound) so applying `@pytest_asyncio.fixture` to a sync function no longer raises a type error before the warning fires.
- Emits `PytestDeprecationWarning` at decoration time when the decorated function is not a coroutine or async generator.
- Adds tests for both the bare-decorator and factory-decorator paths.

Closes #1090