### PR TITLE
fix publish job: pass --repo to gh release edit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,4 +268,4 @@ jobs:
       run: |
         set +e
         TAG_NAME="${GITHUB_REF#refs/tags/}"
-        gh release edit "${TAG_NAME}" --draft=false
+        gh release edit --repo "${GITHUB_REPOSITORY}" "${TAG_NAME}" --draft=false


### PR DESCRIPTION
The \"Publish GitHub Release\" step in the `publish-to-pypi` job fails with:

```
fatal: not a git repository (or any of the parent directories): .git
```

This happens because `gh release edit` tries to detect the target repository from the local `.git` config, but the job only downloads the `dist` artifact — it never runs `actions/checkout`.

Fix: pass `--repo "${GITHUB_REPOSITORY}"` so `gh` uses the standard env variable instead of reading from git.

Reproduces on every tag push — visible in the v1.4.0 release run:
https://github.com/pytest-dev/pytest-asyncio/actions/runs/26444945097/job/77849670861