### PR TITLE
Bump codecov/codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,7 +157,7 @@ jobs:
         coverage combine
         coverage xml
     - name: Upload coverage report
-      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
       with:
         files: coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
Fixes broken GPG validation and unblocks PRs.
see https://github.com/codecov/codecov-action/issues/1956