### PR TITLE
Allow AsyncIterable as a return type for async generator fixtures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
   rev: v1.19.1
   hooks:
   - id: mypy
-    exclude: ^(docs|tests)/.*
+    exclude: ^docs/.*
     additional_dependencies:
     - pytest
 - repo: https://github.com/pre-commit/pygrep-hooks

--- a/changelog.d/1090.fixed.rst
+++ b/changelog.d/1090.fixed.rst
@@ -1,0 +1,1 @@
+Allow `AsyncIterable` as a return type for asynchronous generator fixtures decorated with `pytest_asyncio.fixture`

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
     from asyncio import AbstractEventLoopPolicy
 
 _ScopeName = Literal["session", "package", "module", "class", "function"]
-_R = TypeVar("_R", bound=Awaitable[Any] | AsyncIterator[Any])
+_R = TypeVar("_R", bound=Awaitable | AsyncIterator)
 _P = ParamSpec("_P")
 FixtureFunction = Callable[_P, _R]
 LoopFactory: TypeAlias = Callable[[], AbstractEventLoop]

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -14,6 +14,7 @@ import traceback
 import warnings
 from asyncio import AbstractEventLoop
 from collections.abc import (
+    AsyncIterable,
     AsyncIterator,
     Awaitable,
     Callable,
@@ -69,7 +70,7 @@ if TYPE_CHECKING:
     from asyncio import AbstractEventLoopPolicy
 
 _ScopeName = Literal["session", "package", "module", "class", "function"]
-_R = TypeVar("_R", bound=Awaitable | AsyncIterator)
+_R = TypeVar("_R", bound=Awaitable | AsyncIterable | AsyncIterator)
 _P = ParamSpec("_P")
 FixtureFunction = Callable[_P, _R]
 LoopFactory: TypeAlias = Callable[[], AbstractEventLoop]

--- a/tests/hypothesis/test_base.py
+++ b/tests/hypothesis/test_base.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 
 from textwrap import dedent
 
-import pytest
-from hypothesis import given, strategies as st
 from pytest import Pytester
 
 
@@ -27,18 +25,36 @@ def test_hypothesis_given_decorator_before_asyncio_mark(pytester: Pytester):
     result.assert_outcomes(passed=1)
 
 
-@pytest.mark.asyncio
-@given(st.integers())
-async def test_mark_outer(n):
-    assert isinstance(n, int)
+def test_hypothesis_given_decorator_after_asyncio_mark(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(dedent("""\
+            import pytest
+            from hypothesis import given, strategies as st
+
+            @pytest.mark.asyncio
+            @given(st.integers())
+            async def test_mark_outer(n):
+                assert isinstance(n, int)
+            """))
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
+    result.assert_outcomes(passed=1)
 
 
-@pytest.mark.parametrize("y", [1, 2])
-@given(x=st.none())
-@pytest.mark.asyncio
-async def test_mark_and_parametrize(x, y):
-    assert x is None
-    assert y in (1, 2)
+def test_parametrization(pytester: Pytester):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(dedent("""\
+            import pytest
+            from hypothesis import given, strategies as st
+
+            @pytest.mark.parametrize("y", [1, 2])
+            @given(x=st.none())
+            @pytest.mark.asyncio
+            async def test_mark_and_parametrize(x, y):
+                assert x is None
+                assert y in (1, 2)
+            """))
+    result = pytester.runpytest("--asyncio-mode=strict", "-W default")
+    result.assert_outcomes(passed=2)
 
 
 def test_async_auto_marked(pytester: Pytester):

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -2,7 +2,7 @@
 # to allow type checkers to report usage errors.
 # This is necessary, because most other test code is hidden from type checkers
 # through the use of pytest.Pytester
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator
 
 import pytest_asyncio
 
@@ -19,4 +19,9 @@ async def async_generator0() -> AsyncGenerator:
 
 @pytest_asyncio.fixture
 async def async_generator1() -> AsyncIterator:
+    yield
+
+
+@pytest_asyncio.fixture
+async def async_generator2() -> AsyncIterable:
     yield

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -1,0 +1,22 @@
+# Code in this module does not perform any runtime assertions. It is solely intended
+# to allow type checkers to report usage errors.
+# This is necessary, because most other test code is hidden from type checkers
+# through the use of pytest.Pytester
+from collections.abc import AsyncGenerator, AsyncIterator
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def coroutine() -> None:
+    return None
+
+
+@pytest_asyncio.fixture
+async def async_generator0() -> AsyncGenerator:
+    yield
+
+
+@pytest_asyncio.fixture
+async def async_generator1() -> AsyncIterator:
+    yield

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ skip_install = false
 deps =
     pyright[nodejs]
     pytest
-commands = pyright pytest_asyncio/
+commands = pyright pytest_asyncio/ tests/
 skip_install = true
 
 [gh-actions]


### PR DESCRIPTION
This PR adds *AsyncIterable* to the supported return values of async generator fixtures decorated with *pytest_asyncio.fixture*.

The patch also simplifies the type signature of *pytest_asyncio.fixture* by removing superfluous *Any* specifiers for generic types, extends type checking to test code, and wraps remaining Hypothesis tests into pytest.Pytester to avoid requiring hypothesis as a type checking dependency.

Closes #1090 