### PR TITLE
Fix typo in configuration.rst: "it default" → "it defaults"

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -12,7 +12,7 @@ Determines the default event loop scope of asynchronous fixtures. When this conf
 
 asyncio_default_test_loop_scope
 ===============================
-Determines the default event loop scope of asynchronous tests. When this configuration option is unset, it default to function scope. Possible values are: ``function``, ``class``, ``module``, ``package``, ``session``
+Determines the default event loop scope of asynchronous tests. When this configuration option is unset, it defaults to function scope. Possible values are: ``function``, ``class``, ``module``, ``package``, ``session``
 
 .. _configuration/asyncio_debug:
 


### PR DESCRIPTION
Fix typo in configuration.rst: "it default" → "it defaults"

## What

Corrects a grammatical typo in  in the description of the  option.

**Before:**
> When this configuration option is unset, it default to function scope.

**After:**
> When this configuration option is unset, it defaults to function scope.

## Why

The verb "default" is used in third-person singular present tense here, so it needs the "-s" suffix: "defaults". The adjacent description of  already uses the correct form ("it defaults to the fixture scope").

## How verified

Diff-only change; no functional code touched.
