### PR TITLE
Limit event_loop_policy parametrization to async tests

### DIFF
--- a/changelog.d/796.fixed.rst
+++ b/changelog.d/796.fixed.rst
@@ -1,0 +1,1 @@
+Parametrized ``event_loop_policy`` fixtures no longer parametrize synchronous tests.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -730,6 +730,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         metafunc.definition
     )
     if specialized_item_class is None:
+        _remove_autouse_event_loop_policy_for_sync_tests(metafunc)
         return
 
     asyncio_marker = _resolve_asyncio_marker(metafunc.definition)
@@ -786,6 +787,25 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         indirect=True,
         scope=loop_scope,
     )
+
+
+def _remove_autouse_event_loop_policy_for_sync_tests(
+    metafunc: pytest.Metafunc,
+) -> None:
+    fixture_name = event_loop_policy.__name__
+    fixtureinfo = metafunc.definition._fixtureinfo
+    if fixture_name in fixtureinfo.argnames:
+        return
+    if any(
+        fixture_name in marker.args
+        for marker in metafunc.definition.iter_markers(name="usefixtures")
+    ):
+        return
+    if fixture_name in metafunc.fixturenames:
+        metafunc.fixturenames.remove(fixture_name)
+    if fixture_name in fixtureinfo.names_closure:
+        fixtureinfo.names_closure.remove(fixture_name)
+    fixtureinfo.name2fixturedefs.pop(fixture_name, None)
 
 
 @contextlib.contextmanager

--- a/tests/markers/test_event_loop_policy.py
+++ b/tests/markers/test_event_loop_policy.py
@@ -1,0 +1,40 @@
+from textwrap import dedent
+
+from pytest import Pytester
+
+
+def test_parametrized_loop_policy_does_not_parametrize_sync_tests(
+    pytester: Pytester,
+):
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function")
+    pytester.makepyfile(dedent("""\
+            import asyncio
+
+            import pytest
+
+            class CustomEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+                pass
+
+            @pytest.fixture(
+                params=[
+                    asyncio.DefaultEventLoopPolicy(),
+                    CustomEventLoopPolicy(),
+                ],
+            )
+            def event_loop_policy(request):
+                return request.param
+
+            @pytest.mark.asyncio
+            async def test_async():
+                assert isinstance(
+                    asyncio.get_event_loop_policy(),
+                    (asyncio.DefaultEventLoopPolicy, CustomEventLoopPolicy),
+                )
+
+            def test_sync():
+                assert True
+            """))
+
+    result = pytester.runpytest("--asyncio-mode=strict")
+
+    result.assert_outcomes(passed=3)


### PR DESCRIPTION
## Summary

- stop parametrized `event_loop_policy` autouse fixture overrides from applying to synchronous tests that do not request the fixture
- keep explicit synchronous uses of `event_loop_policy` intact, including direct fixture arguments and `usefixtures`
- add a regression test covering one async test and one sync test with a parametrized policy fixture

Fixes #796

## Tests

- `python -m pytest tests\markers\test_event_loop_policy.py -q -p no:twisted`
- `python -m pytest tests\markers\test_function_scope.py::test_asyncio_mark_respects_parametrized_loop_policies tests\markers\test_function_scope.py::test_event_loop_policy_fixture_override_emits_deprecation_warning tests\markers\test_function_scope.py::test_default_event_loop_policy_fixture_does_not_warn -q -p no:twisted`
- `python -m pytest tests\markers -q -p no:twisted`
- `python -m ruff check pytest_asyncio\plugin.py tests\markers\test_event_loop_policy.py`
- `python -m ruff format --check pytest_asyncio\plugin.py tests\markers\test_event_loop_policy.py`
- `git diff --check`

Note: I used `-p no:twisted` locally because this environment has an unrelated global `pytest-twisted` plugin installed, and it interferes with pytester subprocess runs. The pytest-asyncio tests themselves pass with that unrelated plugin disabled.