### PR TITLE
fix: only warn about asyncio_default_fixture_loop_scope when needed

### DIFF
--- a/changelog.d/1344.fixed.rst
+++ b/changelog.d/1344.fixed.rst
@@ -1,0 +1,1 @@
+Only warn about an unset ``asyncio_default_fixture_loop_scope`` configuration option when an async fixture is actually used.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -935,12 +935,9 @@ def pytest_fixture_setup(fixturedef: FixtureDef, request) -> object | None:
         if not _is_coroutine_or_asyncgen(fixturedef.func):
             return (yield)
     default_loop_scope = request.config.getini("asyncio_default_fixture_loop_scope")
-    loop_scope = (
-        getattr(fixturedef.func, "_loop_scope", None)
-        or default_loop_scope
-        or fixturedef.scope
-    )
-    if not default_loop_scope and not getattr(fixturedef.func, "_loop_scope", None):
+    fixture_loop_scope = getattr(fixturedef.func, "_loop_scope", None)
+    loop_scope = fixture_loop_scope or default_loop_scope or fixturedef.scope
+    if not default_loop_scope and not fixture_loop_scope:
         _warn_default_fixture_loop_scope_unset(request.config)
     runner_fixture_id = f"_{loop_scope}_scoped_runner"
     runner = request.getfixturevalue(runner_fixture_id)

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -293,11 +293,20 @@ def _validate_scope(scope: str | None, option_name: str) -> None:
         )
 
 
+_default_fixture_loop_scope_warning_emitted_for_config: set[int] = set()
+
+
+def _warn_default_fixture_loop_scope_unset(config: Config) -> None:
+    config_id = id(config)
+    if config_id in _default_fixture_loop_scope_warning_emitted_for_config:
+        return
+    _default_fixture_loop_scope_warning_emitted_for_config.add(config_id)
+    warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
+
+
 def pytest_configure(config: Config) -> None:
     default_fixture_loop_scope = config.getini("asyncio_default_fixture_loop_scope")
     _validate_scope(default_fixture_loop_scope, "asyncio_default_fixture_loop_scope")
-    if not default_fixture_loop_scope:
-        warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
 
     default_test_loop_scope = config.getini("asyncio_default_test_loop_scope")
     _validate_scope(default_test_loop_scope, "asyncio_default_test_loop_scope")
@@ -931,6 +940,8 @@ def pytest_fixture_setup(fixturedef: FixtureDef, request) -> object | None:
         or default_loop_scope
         or fixturedef.scope
     )
+    if not default_loop_scope and not getattr(fixturedef.func, "_loop_scope", None):
+        _warn_default_fixture_loop_scope_unset(request.config)
     runner_fixture_id = f"_{loop_scope}_scoped_runner"
     runner = request.getfixturevalue(runner_fixture_id)
     # Prevent the runner closing before the fixture's async teardown.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -293,14 +293,10 @@ def _validate_scope(scope: str | None, option_name: str) -> None:
         )
 
 
-_default_fixture_loop_scope_warning_emitted_for_config: set[int] = set()
-
-
 def _warn_default_fixture_loop_scope_unset(config: Config) -> None:
-    config_id = id(config)
-    if config_id in _default_fixture_loop_scope_warning_emitted_for_config:
+    if getattr(config, "_asyncio_default_fixture_loop_scope_warning_emitted", False):
         return
-    _default_fixture_loop_scope_warning_emitted_for_config.add(config_id)
+    config._asyncio_default_fixture_loop_scope_warning_emitted = True
     warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
 
 

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -52,6 +52,7 @@ from pytest import (
     PytestCollectionWarning,
     PytestDeprecationWarning,
     PytestPluginManager,
+    StashKey,
 )
 
 if sys.version_info >= (3, 11):
@@ -293,10 +294,13 @@ def _validate_scope(scope: str | None, option_name: str) -> None:
         )
 
 
+_DEFAULT_FIXTURE_LOOP_SCOPE_WARNING_EMITTED: StashKey[bool] = StashKey()
+
+
 def _warn_default_fixture_loop_scope_unset(config: Config) -> None:
-    if getattr(config, "_asyncio_default_fixture_loop_scope_warning_emitted", False):
+    if config.stash.get(_DEFAULT_FIXTURE_LOOP_SCOPE_WARNING_EMITTED, False):
         return
-    config._asyncio_default_fixture_loop_scope_warning_emitted = True
+    config.stash[_DEFAULT_FIXTURE_LOOP_SCOPE_WARNING_EMITTED] = True
     warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
 
 

--- a/tests/test_fixture_loop_scopes.py
+++ b/tests/test_fixture_loop_scopes.py
@@ -126,3 +126,48 @@ def test_invalid_default_fixture_loop_scope_raises_error(pytester: Pytester):
             "function, class, module, package, session."
         ]
     )
+
+
+def test_no_warning_for_unset_default_fixture_loop_scope_without_async_fixtures(
+    pytester: Pytester,
+):
+    """Regression test for #1344."""
+    pytester.makeini(dedent("""\
+        [pytest]
+        asyncio_mode = strict
+        """))
+    pytester.makepyfile(dedent("""\
+        def test_no_async():
+            pass
+        """))
+    result = pytester.runpytest_subprocess("-Werror")
+    result.assert_outcomes(passed=1)
+
+
+def test_warning_for_unset_default_fixture_loop_scope_with_async_fixture(
+    pytester: Pytester,
+):
+    pytester.makeini(dedent("""\
+        [pytest]
+        asyncio_mode = strict
+        """))
+    pytester.makepyfile(dedent("""\
+        import pytest
+        import pytest_asyncio
+
+        @pytest_asyncio.fixture
+        async def async_fixture():
+            return 42
+
+        @pytest.mark.asyncio
+        async def test_async(async_fixture):
+            assert async_fixture == 42
+        """))
+    result = pytester.runpytest_subprocess("-Wdefault")
+    result.assert_outcomes(passed=1, warnings=1)
+    result.stdout.fnmatch_lines(
+        [
+            "*PytestDeprecationWarning: The configuration option "
+            "\"asyncio_default_fixture_loop_scope\" is unset.*"
+        ]
+    )

--- a/tests/test_fixture_loop_scopes.py
+++ b/tests/test_fixture_loop_scopes.py
@@ -168,6 +168,6 @@ def test_warning_for_unset_default_fixture_loop_scope_with_async_fixture(
     result.stdout.fnmatch_lines(
         [
             "*PytestDeprecationWarning: The configuration option "
-            "\"asyncio_default_fixture_loop_scope\" is unset.*"
+            '"asyncio_default_fixture_loop_scope" is unset.*'
         ]
     )


### PR DESCRIPTION
Fixes #1344

When pytest-asyncio is installed as a transitive dependency, the plugin currently emits its `PytestDeprecationWarning` about an unset `asyncio_default_fixture_loop_scope` unconditionally from `pytest_configure`. That means any test suite running under `-Werror` will hit an internal error as soon as pytest-asyncio is present, even if the suite has no async tests or fixtures. The reporter saw this with `pytester.runpytest_inprocess`, but the underlying issue is that the warning fires the moment the plugin loads.

As noted in the issue thread, this happens because pytest enables all installed plugins by default. The suggested workaround of passing `-p no:asyncio` works, but it is not reasonable to expect users who never chose to install pytest-asyncio to discover and apply it.

This change moves the warning into `pytest_fixture_setup`, so it is only emitted when an async fixture is actually being set up and neither the global `asyncio_default_fixture_loop_scope` nor a per-fixture `loop_scope` has been configured. A `StashKey` on the `Config` object keeps track of whether the warning has already been emitted, preventing it from repeating for every async fixture.

I added regression tests for both sides of the behavior: a plain synchronous test now passes under `-Werror` without triggering the warning, while a suite that does use an async fixture still sees the deprecation warning as expected.