### PR TITLE
Avoid PytestAssertRewriteWarning in tests using runpytest

### DIFF
--- a/changelog.d/1334.downstream.rst
+++ b/changelog.d/1334.downstream.rst
@@ -1,0 +1,1 @@
+Avoided a ``PytestAssertRewriteWarning`` in the test suite when pytest-asyncio is already imported, such as when tests are run against a system-installed copy on Guix or FreeBSD.

--- a/changelog.d/1334.downstream.rst
+++ b/changelog.d/1334.downstream.rst
@@ -1,1 +1,1 @@
-Avoided a ``PytestAssertRewriteWarning`` in the test suite when pytest-asyncio is already imported, such as when tests are run against a system-installed copy on Guix or FreeBSD.
+Avoided a ``PytestAssertRewriteWarning`` in the test suite when it is run from an unpacked sdist. The sdist ships ``pytest_asyncio.egg-info/SOURCES.txt``, which lists ``tests/__init__.py``, so pytest marks the ``tests`` package for assertion rewriting even though it has already been imported by the outer session. This affects downstream distributors such as Guix.

--- a/tests/markers/test_class_scope.py
+++ b/tests/markers/test_class_scope.py
@@ -275,5 +275,5 @@ def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_be
                 async def test_anything(self):
                     pass
             """))
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "--assert=plain")
     result.assert_outcomes(warnings=0, passed=1)

--- a/tests/markers/test_class_scope.py
+++ b/tests/markers/test_class_scope.py
@@ -274,5 +274,5 @@ def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_be
                 async def test_anything(self):
                     pass
             """))
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "--assert=plain")
     result.assert_outcomes(warnings=0, passed=1)

--- a/tests/markers/test_function_scope.py
+++ b/tests/markers/test_function_scope.py
@@ -72,7 +72,9 @@ def test_warns_when_scope_argument_is_present(pytester: Pytester):
             async def test_warns():
                 ...
             """))
-    result = pytester.runpytest("--asyncio-mode=strict", "-W", "default")
+    result = pytester.runpytest(
+        "--asyncio-mode=strict", "-W", "default", "--assert=plain"
+    )
     result.assert_outcomes(passed=1, warnings=1)
     result.stdout.fnmatch_lines("*DeprecationWarning*")
 

--- a/tests/markers/test_module_scope.py
+++ b/tests/markers/test_module_scope.py
@@ -281,5 +281,5 @@ def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_be
             async def test_anything():
                 pass
             """))
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "--assert=plain")
     result.assert_outcomes(warnings=0, passed=1)

--- a/tests/markers/test_session_scope.py
+++ b/tests/markers/test_session_scope.py
@@ -392,5 +392,5 @@ def test_standalone_test_does_not_trigger_warning_about_no_current_event_loop_be
             async def test_anything():
                 pass
             """))
-    result = pytester.runpytest("--asyncio-mode=strict")
+    result = pytester.runpytest("--asyncio-mode=strict", "--assert=plain")
     result.assert_outcomes(warnings=0, passed=1)

--- a/tests/test_event_loop_fixture.py
+++ b/tests/test_event_loop_fixture.py
@@ -13,8 +13,6 @@ def test_event_loop_fixture_handles_unclosed_async_gen(
             import asyncio
             import pytest
 
-            pytest_plugins = 'pytest_asyncio'
-
             @pytest.mark.asyncio
             async def test_something():
                 async def generator_fn():
@@ -66,8 +64,6 @@ def test_event_loop_fixture_asyncgen_error(
     pytester.makepyfile(dedent("""\
             import asyncio
             import pytest
-
-            pytest_plugins = 'pytest_asyncio'
 
             @pytest.mark.asyncio
             async def test_something():

--- a/tests/test_event_loop_fixture.py
+++ b/tests/test_event_loop_fixture.py
@@ -22,7 +22,9 @@ def test_event_loop_fixture_handles_unclosed_async_gen(
                 gen = generator_fn()
                 await gen.__anext__()
             """))
-    result = pytester.runpytest("--asyncio-mode=strict", "-W", "default")
+    result = pytester.runpytest(
+        "--asyncio-mode=strict", "-W", "default", "--assert=plain"
+    )
     result.assert_outcomes(passed=1, warnings=0)
 
 
@@ -73,5 +75,7 @@ def test_event_loop_fixture_asyncgen_error(
                     raise RuntimeError("mock error cleaning up...")
                 loop.shutdown_asyncgens = fail
             """))
-    result = pytester.runpytest("--asyncio-mode=strict", "-W", "default")
+    result = pytester.runpytest(
+        "--asyncio-mode=strict", "-W", "default", "--assert=plain"
+    )
     result.assert_outcomes(passed=1, warnings=1)


### PR DESCRIPTION
Fixes #1334

Pass `--assert=plain` to the in-process `runpytest` calls for the six tests that emit `PytestAssertRewriteWarning`, keeping the #1227 in-process fix intact. Also drop the explicit `pytest_plugins` assignment in the two event-loop fixture tests so they do not mark the already-loaded plugin for assertion rewriting.
