### PR TITLE
Fix decorator order

### DIFF
--- a/tests/modes/test_auto_mode.py
+++ b/tests/modes/test_auto_mode.py
@@ -113,8 +113,8 @@ def test_auto_mode_static_method_fixture(pytester: Pytester):
 
         class TestA:
 
-            @staticmethod
             @pytest.fixture
+            @staticmethod
             async def fixture_a():
                 await asyncio.sleep(0)
                 return 1


### PR DESCRIPTION
The pytest-asyncio test suite is failing when run using the pytest main branch due to a warning when fixtures get wrapped with a decorator.

reference: https://github.com/pytest-dev/pytest/commit/264846d02f5c19ec481fc2f0ffb8892f8f60cd2e