### PR TITLE
Fix runner setup order for async tests

### DIFF
--- a/changelog.d/818.fixed.rst
+++ b/changelog.d/818.fixed.rst
@@ -1,0 +1,2 @@
+Set up the event loop runner before synchronous fixtures used by async tests so
+fixture monkeypatching cannot interfere with event loop creation.

--- a/pytest_asyncio/plugin.py
+++ b/pytest_asyncio/plugin.py
@@ -549,7 +549,7 @@ class PytestAsyncioFunction(Function):
     def setup(self) -> None:
         runner_fixture_id = f"_{self._loop_scope}_scoped_runner"
         if runner_fixture_id not in self.fixturenames:
-            self.fixturenames.append(runner_fixture_id)
+            self.fixturenames.insert(0, runner_fixture_id)
         # When loop factories are configured, resolve the loop factory
         # fixture early so that a factory variant change cascades cache
         # invalidation before any async fixture checks its cache.

--- a/tests/test_set_event_loop.py
+++ b/tests/test_set_event_loop.py
@@ -133,6 +133,38 @@ def test_asyncio_run_after_async_fixture_does_not_leak_loop(
     result.assert_outcomes(passed=2)
 
 
+def test_runner_encompasses_sync_fixtures(pytester: Pytester):
+    pytester.makeini(dedent("""\
+            [pytest]
+            asyncio_default_fixture_loop_scope = function
+            """))
+    pytester.makepyfile(dedent("""\
+            import pytest
+            import pytest_asyncio.plugin
+
+            pytest_plugins = "pytest_asyncio"
+
+
+            class BrokenRunner:
+                def __init__(self, *args, **kwargs):
+                    raise RuntimeError(
+                        "Runner constructed while user fixture is active"
+                    )
+
+
+            @pytest.fixture
+            def patch_runner(monkeypatch):
+                monkeypatch.setattr(pytest_asyncio.plugin, "Runner", BrokenRunner)
+
+
+            @pytest.mark.asyncio
+            async def test_async_function_uses_sync_fixture(patch_runner):
+                pass
+            """))
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
 @pytest.mark.parametrize("test_loop_scope", ("module", "package", "session"))
 @pytest.mark.parametrize(
     "loop_breaking_action",


### PR DESCRIPTION
Fixes #818

## Reproduction
A synchronous fixture can monkeypatch event-loop creation state before pytest-asyncio creates its runner for an async test. The added regression test simulates the reported `pytest-mock`/socket lifecycle problem by replacing `pytest_asyncio.plugin.Runner` from a sync fixture; on `main`, the runner is constructed while the fixture is active and the test errors.

## Root cause
`PytestAsyncioFunction.setup()` appended the scoped runner fixture to the end of `fixturenames`. Pytest therefore set up user fixtures first and set up/teared down the runner inside those fixtures' lifetime.

## Fix
Insert the runner fixture at the front of `fixturenames` so the event loop runner encompasses synchronous fixtures used by async tests. This preserves normal async test behavior while preventing user fixture monkeypatching from interfering with event loop creation.

## Compatibility notes
This only changes fixture ordering for pytest-asyncio's internal runner fixture. No public API or configuration changes are introduced.

## Validation
- `python -m pytest tests/test_set_event_loop.py::test_runner_encompasses_sync_fixtures -q`: 1 passed.
- Regression check with the fix reverted: `tests/test_set_event_loop.py::test_runner_encompasses_sync_fixtures` failed with `RuntimeError: Runner constructed while user fixture is active`.
- `python -m pytest tests/test_set_event_loop.py -q`: 61 passed, 1 failed. The failure is pre-existing on this Windows/Python 3.13 + pytest 9.1.1 environment: `test_asyncio_run_after_async_fixture_does_not_leak_loop` errors with `PytestAssertRewriteWarning: Module already imported so cannot be rewritten; pytest_asyncio` and reproduces with the runner-order fix reverted.
- `python -m pytest`: 290 passed, 3 skipped, 6 failed. The failures are the same pre-existing Windows/Python 3.13 + pytest 9.1.1 subprocess/in-process loop/assert-rewrite failures and are unrelated to this change.
- `pre-commit run --files pytest_asyncio/plugin.py tests/test_set_event_loop.py changelog.d/818.fixed.rst`: passed.